### PR TITLE
fix: restore room state on lobby reload for realtime sync

### DIFF
--- a/src/app/_components/room/create-room/create-room.component.ts
+++ b/src/app/_components/room/create-room/create-room.component.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { QRCodeComponent } from 'angularx-qrcode';
 import { RoomService, GameRoom } from '../../../services/room/room.service';
+import { MemberService, CreateMemberData } from '../../../services/member/member.service';
 import { AuthService } from '../../../services/auth/auth.service';
 
 /**
@@ -28,6 +29,7 @@ import { AuthService } from '../../../services/auth/auth.service';
 })
 export class CreateRoomComponent {
   private readonly roomService = inject(RoomService);
+  private readonly memberService = inject(MemberService);
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
@@ -125,13 +127,63 @@ export class CreateRoomComponent {
   }
 
   /**
-   * Navigate to the created room's lobby
+   * Enter the room as host and navigate to lobby
    */
-  enterRoom(): void {
+  async enterRoom(): Promise<void> {
     const room = this.createdRoom();
-    if (room) {
-      this.router.navigate(['/room', room.$id]);
+    if (!room) {
+      return;
     }
+
+    this.isLoading.set(true);
+    this.error.set(null);
+
+    try {
+      // Get current user info
+      const user = this.authService.currentUser();
+      const displayName = user?.name || 'Host';
+
+      // Create host member
+      const memberData: CreateMemberData = {
+        roomId: room.$id,
+        userId: user?.$id || null,
+        deviceId: user ? null : this.getDeviceId(),
+        displayName,
+        role: 'host',
+        isOnline: true,
+        totalSipsGiven: 0,
+        totalSipsTaken: 0,
+        totalGamesPlayed: 0,
+        gameStats: {},
+      };
+
+      const member = await this.memberService.createMember(memberData);
+
+      // Set as current member
+      this.memberService.setCurrentMember(member);
+
+      // Update room with host member ID
+      await this.roomService.updateRoom(room.$id, { hostMemberId: member.$id });
+
+      // Navigate to lobby
+      await this.router.navigate(['/room', room.$id]);
+    } catch (err) {
+      this.error.set(this.getErrorMessage(err));
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+
+  /**
+   * Generate or retrieve device ID for guest users
+   */
+  private getDeviceId(): string {
+    let deviceId = localStorage.getItem('ketal_device_id');
+    if (!deviceId) {
+      deviceId = crypto.randomUUID();
+      localStorage.setItem('ketal_device_id', deviceId);
+    }
+    return deviceId;
   }
 
   /**

--- a/src/app/_components/room/create-room/create-room.component.ts
+++ b/src/app/_components/room/create-room/create-room.component.ts
@@ -5,7 +5,6 @@ import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { QRCodeComponent } from 'angularx-qrcode';
 import { RoomService, GameRoom } from '../../../services/room/room.service';
-import { MemberService, CreateMemberData } from '../../../services/member/member.service';
 import { AuthService } from '../../../services/auth/auth.service';
 
 /**
@@ -29,7 +28,6 @@ import { AuthService } from '../../../services/auth/auth.service';
 })
 export class CreateRoomComponent {
   private readonly roomService = inject(RoomService);
-  private readonly memberService = inject(MemberService);
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
@@ -127,63 +125,13 @@ export class CreateRoomComponent {
   }
 
   /**
-   * Enter the room as host and navigate to lobby
+   * Navigate to the created room's lobby
    */
-  async enterRoom(): Promise<void> {
+  enterRoom(): void {
     const room = this.createdRoom();
-    if (!room) {
-      return;
+    if (room) {
+      this.router.navigate(['/room', room.$id]);
     }
-
-    this.isLoading.set(true);
-    this.error.set(null);
-
-    try {
-      // Get current user info
-      const user = this.authService.currentUser();
-      const displayName = user?.name || 'Host';
-
-      // Create host member
-      const memberData: CreateMemberData = {
-        roomId: room.$id,
-        userId: user?.$id || null,
-        deviceId: user ? null : this.getDeviceId(),
-        displayName,
-        role: 'host',
-        isOnline: true,
-        totalSipsGiven: 0,
-        totalSipsTaken: 0,
-        totalGamesPlayed: 0,
-        gameStats: {},
-      };
-
-      const member = await this.memberService.createMember(memberData);
-
-      // Set as current member
-      this.memberService.setCurrentMember(member);
-
-      // Update room with host member ID
-      await this.roomService.updateRoom(room.$id, { hostMemberId: member.$id });
-
-      // Navigate to lobby
-      await this.router.navigate(['/room', room.$id]);
-    } catch (err) {
-      this.error.set(this.getErrorMessage(err));
-    } finally {
-      this.isLoading.set(false);
-    }
-  }
-
-  /**
-   * Generate or retrieve device ID for guest users
-   */
-  private getDeviceId(): string {
-    let deviceId = localStorage.getItem('ketal_device_id');
-    if (!deviceId) {
-      deviceId = crypto.randomUUID();
-      localStorage.setItem('ketal_device_id', deviceId);
-    }
-    return deviceId;
   }
 
   /**

--- a/src/app/_components/room/lobby/lobby.component.ts
+++ b/src/app/_components/room/lobby/lobby.component.ts
@@ -1,11 +1,13 @@
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { QRCodeComponent } from 'angularx-qrcode';
-import { RoomService, GameRoom } from '../../../services/room/room.service';
+import { RoomService } from '../../../services/room/room.service';
 import { MemberService, GameMember, MemberRole } from '../../../services/member/member.service';
 import { RealtimeService, GameMember as RealtimeGameMember } from '../../../services/realtime/realtime.service';
+import { AuthService } from '../../../services/auth/auth.service';
+import { GuestService } from '../../../services/guest/guest.service';
 import { KetalSessionService, KetalPlayer } from '../../../services/ketal-session/ketal-session.service';
 
 /**
@@ -31,9 +33,12 @@ import { KetalSessionService, KetalPlayer } from '../../../services/ketal-sessio
 })
 export class LobbyComponent implements OnInit {
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
   private readonly roomService = inject(RoomService);
   private readonly memberService = inject(MemberService);
   private readonly realtimeService = inject(RealtimeService);
+  private readonly authService = inject(AuthService);
+  private readonly guestService = inject(GuestService);
   private readonly ketalSessionService = inject(KetalSessionService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -103,9 +108,79 @@ export class LobbyComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.loadRoomMembers();
-    this.subscribeToMemberUpdates();
+    this.initializeLobby();
     this.registerCleanup();
+  }
+
+  /**
+   * Initialize lobby: restore room/member state from route param if needed,
+   * then load members and subscribe to realtime updates.
+   */
+  private async initializeLobby(): Promise<void> {
+    try {
+      this.isLoading.set(true);
+      this.error.set(null);
+
+      // If currentRoom is null (e.g. after page reload), restore from route param
+      if (!this.currentRoom()) {
+        const roomId = this.route.snapshot.paramMap.get('id');
+        if (!roomId) {
+          await this.router.navigate(['/']);
+          return;
+        }
+
+        const room = await this.roomService.getRoomById(roomId);
+        if (!room) {
+          this.error.set('lobby.errors.roomNotFound');
+          await this.router.navigate(['/']);
+          return;
+        }
+
+        this.roomService.setCurrentRoom(room);
+      }
+
+      // Recover member identity if currentMember is null
+      if (!this.currentMember()) {
+        await this.recoverMemberIdentity();
+      }
+
+      // Load room members
+      await this.loadRoomMembers();
+
+      // Subscribe to realtime member updates
+      this.subscribeToMemberUpdates();
+    } catch (err) {
+      this.error.set(this.getErrorMessage(err));
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+
+  /**
+   * Recover the current user's member record in this room
+   * by matching userId or deviceId against existing members.
+   */
+  private async recoverMemberIdentity(): Promise<void> {
+    const room = this.currentRoom();
+    if (!room) {
+      return;
+    }
+
+    const currentUser = this.authService.currentUser();
+    const deviceId = this.guestService.getOrCreateDeviceId();
+
+    const existingMember = await this.memberService.getMemberByUserOrDevice(room.$id, currentUser?.$id, deviceId);
+
+    if (existingMember) {
+      this.memberService.setCurrentMember(existingMember);
+
+      // Mark as online
+      try {
+        await this.memberService.updateMember(existingMember.$id, { isOnline: true });
+      } catch {
+        // Non-critical: ignore online status update failures
+      }
+    }
   }
 
   /**
@@ -130,6 +205,11 @@ export class LobbyComponent implements OnInit {
   private subscribeToMemberUpdates(): void {
     const room = this.currentRoom();
     if (!room) {
+      return;
+    }
+
+    // Avoid duplicate subscriptions
+    if (this.memberSubscriptionId) {
       return;
     }
 

--- a/src/app/_components/room/lobby/lobby.component.ts
+++ b/src/app/_components/room/lobby/lobby.component.ts
@@ -185,15 +185,16 @@ export class LobbyComponent implements OnInit {
     // Mark as online
     try {
       await this.memberService.updateMember(existingMember.$id, { isOnline: true });
-    } catch {
-      // Non-critical: ignore online status update failures
+    } catch (err) {
+      console.warn('Failed to update online status (non-critical):', err);
     }
   }
 
   /**
    * Load all members for the current room
+   * @param showLoading - Whether to set isLoading signal (false for realtime-triggered reloads to avoid UI flicker)
    */
-  private async loadRoomMembers(): Promise<void> {
+  private async loadRoomMembers(showLoading = true): Promise<void> {
     const room = this.currentRoom();
     if (!room) {
       return;
@@ -201,11 +202,17 @@ export class LobbyComponent implements OnInit {
 
     try {
       this.isMembersLoading = true;
+      if (showLoading) {
+        this.isLoading.set(true);
+      }
       await this.memberService.getMembersByRoom(room.$id);
     } catch (err) {
       this.error.set(this.getErrorMessage(err));
     } finally {
       this.isMembersLoading = false;
+      if (showLoading) {
+        this.isLoading.set(false);
+      }
     }
   }
 
@@ -220,6 +227,7 @@ export class LobbyComponent implements OnInit {
 
     // Avoid duplicate subscriptions
     if (this.memberSubscriptionId) {
+      console.warn('subscribeToMemberUpdates: subscription already active, skipping duplicate');
       return;
     }
 
@@ -228,8 +236,8 @@ export class LobbyComponent implements OnInit {
       if (this.isMembersLoading) {
         return;
       }
-      // Refresh members list when any member in the room changes
-      this.loadRoomMembers();
+      // Refresh members list without UI flicker on realtime updates
+      this.loadRoomMembers(false);
     });
   }
 

--- a/src/app/_components/room/lobby/lobby.component.ts
+++ b/src/app/_components/room/lobby/lobby.component.ts
@@ -45,6 +45,9 @@ export class LobbyComponent implements OnInit {
   /** Subscription ID for member realtime updates */
   private memberSubscriptionId: string | null = null;
 
+  /** Guard flag to prevent concurrent member loads */
+  private isMembersLoading = false;
+
   /** Loading state for async operations */
   readonly isLoading = signal(false);
 
@@ -144,11 +147,11 @@ export class LobbyComponent implements OnInit {
         await this.recoverMemberIdentity();
       }
 
+      // Subscribe to realtime member updates BEFORE loading to avoid missing events
+      this.subscribeToMemberUpdates();
+
       // Load room members
       await this.loadRoomMembers();
-
-      // Subscribe to realtime member updates
-      this.subscribeToMemberUpdates();
     } catch (err) {
       this.error.set(this.getErrorMessage(err));
     } finally {
@@ -171,15 +174,19 @@ export class LobbyComponent implements OnInit {
 
     const existingMember = await this.memberService.getMemberByUserOrDevice(room.$id, currentUser?.$id, deviceId);
 
-    if (existingMember) {
-      this.memberService.setCurrentMember(existingMember);
+    if (!existingMember) {
+      console.warn('No member found, redirecting to join');
+      this.router.navigate(['/room/join', room.code]);
+      return;
+    }
 
-      // Mark as online
-      try {
-        await this.memberService.updateMember(existingMember.$id, { isOnline: true });
-      } catch {
-        // Non-critical: ignore online status update failures
-      }
+    this.memberService.setCurrentMember(existingMember);
+
+    // Mark as online
+    try {
+      await this.memberService.updateMember(existingMember.$id, { isOnline: true });
+    } catch {
+      // Non-critical: ignore online status update failures
     }
   }
 
@@ -193,9 +200,12 @@ export class LobbyComponent implements OnInit {
     }
 
     try {
+      this.isMembersLoading = true;
       await this.memberService.getMembersByRoom(room.$id);
     } catch (err) {
       this.error.set(this.getErrorMessage(err));
+    } finally {
+      this.isMembersLoading = false;
     }
   }
 
@@ -214,6 +224,10 @@ export class LobbyComponent implements OnInit {
     }
 
     this.memberSubscriptionId = this.realtimeService.subscribeToMembers(room.$id, (_member: RealtimeGameMember) => {
+      // Skip if already loading to prevent UI flicker
+      if (this.isMembersLoading) {
+        return;
+      }
       // Refresh members list when any member in the room changes
       this.loadRoomMembers();
     });

--- a/src/app/services/room/room.service.spec.ts
+++ b/src/app/services/room/room.service.spec.ts
@@ -323,12 +323,19 @@ describe('RoomService', () => {
       expect(result).toEqual(mockGameRoom);
     });
 
-    it('should return null when room not found', async () => {
-      mockDatabases.getDocument.and.rejectWith(new Error('Document not found'));
+    it('should return null when room not found (404)', async () => {
+      const notFoundError = { code: 404, message: 'Document not found' };
+      mockDatabases.getDocument.and.rejectWith(notFoundError);
 
       const result = await service.getRoomById('nonexistent');
 
       expect(result).toBeNull();
+    });
+
+    it('should throw error for non-404 errors', async () => {
+      mockDatabases.getDocument.and.rejectWith(new Error('Server error'));
+
+      await expectAsync(service.getRoomById('room123')).toBeRejectedWithError('Failed to get room: Server error');
     });
   });
 

--- a/src/app/services/room/room.service.spec.ts
+++ b/src/app/services/room/room.service.spec.ts
@@ -10,6 +10,7 @@ describe('RoomService', () => {
   let mockDatabases: {
     createDocument: jasmine.Spy;
     deleteDocument: jasmine.Spy;
+    getDocument: jasmine.Spy;
     listDocuments: jasmine.Spy;
     updateDocument: jasmine.Spy;
   };
@@ -46,6 +47,7 @@ describe('RoomService', () => {
     mockDatabases = {
       createDocument: jasmine.createSpy('createDocument'),
       deleteDocument: jasmine.createSpy('deleteDocument'),
+      getDocument: jasmine.createSpy('getDocument'),
       listDocuments: jasmine.createSpy('listDocuments'),
       updateDocument: jasmine.createSpy('updateDocument'),
     };
@@ -308,6 +310,25 @@ describe('RoomService', () => {
       await expectAsync(service.getRoomByInviteToken('550e8400-e29b-41d4-a716-446655440000')).toBeRejectedWithError(
         'Failed to find room by invite token: Query failed'
       );
+    });
+  });
+
+  describe('getRoomById', () => {
+    it('should find a room by its document ID', async () => {
+      mockDatabases.getDocument.and.resolveTo(mockRoomDocument);
+
+      const result = await service.getRoomById('room123');
+
+      expect(mockDatabases.getDocument).toHaveBeenCalledWith('fug', 'fug_game_rooms', 'room123');
+      expect(result).toEqual(mockGameRoom);
+    });
+
+    it('should return null when room not found', async () => {
+      mockDatabases.getDocument.and.rejectWith(new Error('Document not found'));
+
+      const result = await service.getRoomById('nonexistent');
+
+      expect(result).toBeNull();
     });
   });
 

--- a/src/app/services/room/room.service.ts
+++ b/src/app/services/room/room.service.ts
@@ -206,6 +206,23 @@ export class RoomService {
   }
 
   /**
+   * Find a room by its Appwrite document ID
+   */
+  async getRoomById(roomId: string): Promise<GameRoom | null> {
+    try {
+      const document = await this.appwrite.databases.getDocument(
+        this.appwrite.databaseId,
+        COLLECTION_GAME_ROOMS,
+        roomId
+      );
+
+      return this.mapDocumentToGameRoom(document);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Get all rooms
    */
   async getMyRooms(): Promise<GameRoom[]> {

--- a/src/app/services/room/room.service.ts
+++ b/src/app/services/room/room.service.ts
@@ -217,9 +217,13 @@ export class RoomService {
       );
 
       return this.mapDocumentToGameRoom(document);
-    } catch (error) {
-      console.warn('getRoomById failed:', error);
-      return null;
+    } catch (error: unknown) {
+      // Return null for 404 (document not found), re-throw other errors
+      if (error instanceof Object && 'code' in error && (error as { code: number }).code === 404) {
+        return null;
+      }
+      console.warn('getRoomById failed with unexpected error:', error);
+      throw new Error(`Failed to get room: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 

--- a/src/app/services/room/room.service.ts
+++ b/src/app/services/room/room.service.ts
@@ -217,7 +217,8 @@ export class RoomService {
       );
 
       return this.mapDocumentToGameRoom(document);
-    } catch {
+    } catch (error) {
+      console.warn('getRoomById failed:', error);
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- Add getRoomById() to fetch room from Appwrite by document ID
- Restore room and member state from URL on page reload
- Recover member identity after reload
- Fix realtime subscription that silently failed when currentRoom was null

## Bugs fixed
- BUG-9: Realtime room sync broken - host doesn't see new players
- After reload, host loses membership and room shows 0/10 players

## Test plan
- [ ] Create room → enter lobby → reload → still shows room with members
- [ ] Player 2 joins → host sees them in real-time
- [ ] Host role preserved after reload
- [ ] WebSocket connection established on lobby load