### PR TITLE
feat: minimum 2 players validation to start game

### DIFF
--- a/src/app/_shared/_components/footer/footer.component.html
+++ b/src/app/_shared/_components/footer/footer.component.html
@@ -185,6 +185,12 @@
         ></button>
       </div>
     }
+    @if (needsMorePlayers() && gameSrv.isNewGame() && isPlayersPage()) {
+      <div class="mb-2 text-center white-background">
+        <hr class="mb-2" />
+        <small class="text-muted" [translate]="'Label_MinimumPlayers'"></small>
+      </div>
+    }
   </div>
   }
 </div>

--- a/src/app/_shared/_components/footer/footer.component.spec.ts
+++ b/src/app/_shared/_components/footer/footer.component.spec.ts
@@ -167,14 +167,38 @@ describe('FooterComponent', () => {
   });
 
   describe('hasPlayers', () => {
-    it('should return true when players exist', () => {
-      mockPlayerHelperService.getPlayers.and.returnValue([mockPlayer]);
+    it('should return true when 2 or more players exist', () => {
+      const secondPlayer = { ...mockPlayer, id: '2', name: 'Player 2' };
+      mockPlayerHelperService.getPlayers.and.returnValue([mockPlayer, secondPlayer]);
       expect(component.hasPlayers()).toBeTrue();
+    });
+
+    it('should return false when only 1 player', () => {
+      mockPlayerHelperService.getPlayers.and.returnValue([mockPlayer]);
+      expect(component.hasPlayers()).toBeFalse();
     });
 
     it('should return false when no players', () => {
       mockPlayerHelperService.getPlayers.and.returnValue([]);
       expect(component.hasPlayers()).toBeFalse();
+    });
+  });
+
+  describe('needsMorePlayers', () => {
+    it('should return true when exactly 1 player exists', () => {
+      mockPlayerHelperService.getPlayers.and.returnValue([mockPlayer]);
+      expect(component.needsMorePlayers()).toBeTrue();
+    });
+
+    it('should return false when 2 or more players exist', () => {
+      const secondPlayer = { ...mockPlayer, id: '2', name: 'Player 2' };
+      mockPlayerHelperService.getPlayers.and.returnValue([mockPlayer, secondPlayer]);
+      expect(component.needsMorePlayers()).toBeFalse();
+    });
+
+    it('should return false when no players exist', () => {
+      mockPlayerHelperService.getPlayers.and.returnValue([]);
+      expect(component.needsMorePlayers()).toBeFalse();
     });
   });
 

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -109,7 +109,12 @@ export class FooterComponent {
   }
 
   hasPlayers(): boolean {
-    return this.playerHelper?.getPlayers()?.length > 0;
+    return this.playerHelper?.getPlayers()?.length > 1;
+  }
+
+  needsMorePlayers(): boolean {
+    const count = this.playerHelper?.getPlayers()?.length ?? 0;
+    return count > 0 && count < 2;
   }
 
   async beginGame(): Promise<void> {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -33,6 +33,7 @@
   "Warning": "Warning",
   "Assign_All_Sips": "Each user that owned the drawed card have to use the icon <i class=\"fa fa-glass\"></i> to give sips",
   "Assign_All_Given_Sips": " Please assign all sips before saving",
+  "Label_MinimumPlayers": "Minimum 2 players required to start the game",
   "Summary_Mode_Selection": "Activate summary at ending of the game",
   "auth": {
     "login": "Log in",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -33,6 +33,7 @@
   "Warning": "Attention",
   "Assign_All_Sips": "Chaque utilisateur possédant la carte tirée doit utiliser l'icône <i class=\"fa fa-glass\"></i>  afin d'assigner ses gorgées.",
   "Assign_All_Given_Sips": "Donnes toutes les gorgées d'abbord",
+  "Label_MinimumPlayers": "Minimum 2 joueurs requis pour commencer la partie",
   "Summary_Mode_Selection": "Activer le résumé en fin de partie",
   "auth": {
     "login": "Se connecter",


### PR DESCRIPTION
## Summary
- Change `hasPlayers()` in footer component to require `length > 1` (minimum 2 players) instead of `length > 0`
- Add `needsMorePlayers()` method to detect when exactly 1 player exists and show a validation message
- Add `Label_MinimumPlayers` translation key in both FR and EN i18n files
- Update and add unit tests for the new validation logic

## Test plan
- [x] Unit tests pass (829/830 -- 1 pre-existing failure in `player.helper.spec.ts` unrelated to this change)
- [ ] Verify "Start Game" button is hidden when only 1 player is added
- [ ] Verify "Minimum 2 players" message appears when only 1 player exists
- [ ] Verify "Start Game" button appears when 2+ players are added
- [ ] Verify message disappears when 2+ players are added