### PR TITLE
fix: phase 2 card sizes, player card sizes, and quit button

### DIFF
--- a/src/app/_components/players/player-card/player-card.component.scss
+++ b/src/app/_components/players/player-card/player-card.component.scss
@@ -7,9 +7,11 @@
 }
 
 ::ng-deep .card-group .card-container {
+  width: 55px;
+  min-height: auto;
+
   @media (max-width: 768px) {
-    width: auto;
-    flex: 1 1 0;
+    width: 40px;
   }
 }
 

--- a/src/app/_shared/_components/header/header.component.html
+++ b/src/app/_shared/_components/header/header.component.html
@@ -21,7 +21,7 @@
                 <span class="ms-2" [translate]="'Button_GoToMenu'"></span>
               </button>
               <button type="button" class="btn btn-secondary" (click)="showQuitConfirmation()">
-                <fa-icon [icon]="['far', 'circle-xmark']"></fa-icon>
+                <fa-icon [icon]="['fas', 'right-from-bracket']"></fa-icon>
                 <span class="ms-2" [translate]="'Button_QuitGame'"></span>
               </button>
             </div>

--- a/src/app/_shared/_components/playing-card/playing-card.component.scss
+++ b/src/app/_shared/_components/playing-card/playing-card.component.scss
@@ -1,7 +1,6 @@
 .card-container {
   position: relative;
   width: 70px;
-  max-width: 100%;
   min-height: 90px;
 
   &.left-overlap {
@@ -15,7 +14,6 @@
       margin-left: -20px;
     }
   }
-
 
   &.emphasis {
     box-shadow: 0 0 0.5rem 0.25rem rgba(127, 255, 212, 0.7);

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -15,7 +15,7 @@
   "Button_Add": "Hinzufügen",
   "Button_BeginGame": "Grosse Guinze starten",
   "Button_ExitGame": "Spiel beenden",
-  "Button_QuitGame": "Neues Spiel",
+  "Button_QuitGame": "Beenden",
   "Button_GoToMenu": "Menü",
   "Button_ResumeGame": "Spiel läuft - Fortsetzen",
   "Button_Cancel": "Abbrechen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -17,7 +17,7 @@
   "Button_Add": "Add",
   "Button_BeginGame": "Starting the Grosse Guinze",
   "Button_ExitGame": "Exit game",
-  "Button_QuitGame": "New game",
+  "Button_QuitGame": "Quit",
   "Button_GoToMenu": "Menu",
   "Button_ResumeGame": "Game in progress - Resume",
   "Button_Cancel": "Cancel",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -15,7 +15,7 @@
   "Button_Add": "Ajouter",
   "Button_BeginGame": "Débuter la Grosse Guinze",
   "Button_ExitGame": "Arrêter la partie en cours",
-  "Button_QuitGame": "Nouvelle partie",
+  "Button_QuitGame": "Quitter",
   "Button_GoToMenu": "Menu",
   "Button_ResumeGame": "Partie en cours - Reprendre",
   "Button_Cancel": "Annuler",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -15,7 +15,7 @@
   "Button_Add": "Toevoegen",
   "Button_BeginGame": "Start de Grosse Guinze",
   "Button_ExitGame": "Spel verlaten",
-  "Button_QuitGame": "Nieuw spel",
+  "Button_QuitGame": "Stoppen",
   "Button_GoToMenu": "Menu",
   "Button_ResumeGame": "Spel bezig - Hervatten",
   "Button_Cancel": "Annuleren",


### PR DESCRIPTION
## Summary
- **T1**: Remove `max-width: 100%` from `.card-container` in playing-card component so overlapping cards in phase 2 ("Tu bois"/"Tu donnes") render at the same size as the first card
- **T2**: Replace responsive flex layout with fixed widths (55px desktop, 40px mobile) for player card containers to ensure uniform card sizing
- **T3**: Update quit button label from "New game" to "Quit" in all 4 locales (fr/en/nl/de) and change icon from `circle-xmark` to `right-from-bracket`

## Test plan
- [ ] Verify phase 2 cards render at consistent sizes (no shrinking on overlapping cards)
- [ ] Verify player cards display at uniform fixed widths on both mobile and desktop
- [ ] Verify quit button shows "Quitter" (fr), "Quit" (en), "Stoppen" (nl), "Beenden" (de)
- [ ] Verify quit button icon is the right-from-bracket (sign-out) icon
- [ ] All 860 unit tests pass