### PR TITLE
fix: game summary exit navigation and track-by (review 11.3)

### DIFF
--- a/src/app/_components/game/game-summary/game-summary.component.html
+++ b/src/app/_components/game/game-summary/game-summary.component.html
@@ -36,7 +36,7 @@
         </tr>
       </thead>
       <tbody>
-        @for (player of playersSorted(); track player.name; let i = $index) {
+        @for (player of playersSorted(); track $index; let i = $index) {
           <tr [class.table-success]="player.isWinner" [class.table-danger]="player.isLoser">
             <td class="text-start">{{ i + 1 }}</td>
             <td class="text-start">

--- a/src/app/_components/game/game-summary/game-summary.component.spec.ts
+++ b/src/app/_components/game/game-summary/game-summary.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { GameSummaryComponent } from './game-summary.component';
 import { GameService } from '../../../services/game/game.service';
@@ -21,13 +22,19 @@ describe('GameSummaryComponent', () => {
   let component: GameSummaryComponent;
   let fixture: ComponentFixture<GameSummaryComponent>;
   let mockGameService: ReturnType<typeof createMockGameService>;
+  let mockRouter: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
     mockGameService = createMockGameService();
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockRouter.navigate.and.resolveTo(true);
 
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), FontAwesomeIconsModule, GameSummaryComponent],
-      providers: [{ provide: GameService, useValue: mockGameService }],
+      providers: [
+        { provide: GameService, useValue: mockGameService },
+        { provide: Router, useValue: mockRouter },
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
@@ -208,9 +215,10 @@ describe('GameSummaryComponent', () => {
   });
 
   describe('exit action', () => {
-    it('should call resetGame on exit', () => {
+    it('should call resetGame and navigate to home on exit', () => {
       component.exit();
       expect(mockGameService.resetGame).toHaveBeenCalled();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
     });
   });
 

--- a/src/app/_components/game/game-summary/game-summary.component.ts
+++ b/src/app/_components/game/game-summary/game-summary.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { GameService } from '../../../services/game/game.service';
@@ -23,6 +24,7 @@ export interface PlayerSummary {
 })
 export class GameSummaryComponent {
   private readonly gameSrv = inject(GameService);
+  private readonly router = inject(Router);
 
   readonly playersSorted = computed<PlayerSummary[]>(() => {
     const players = this.gameSrv.players();
@@ -82,5 +84,6 @@ export class GameSummaryComponent {
 
   exit(): void {
     this.gameSrv.resetGame();
+    this.router.navigate(['/']);
   }
 }


### PR DESCRIPTION
## Summary
Post-merge review fixes for Story 11.3:
- **C1 fix**: `exit()` now navigates to home (`/`) instead of just resetting the game (same as replay)
- **C2 fix**: `@for track player.name` → `track $index` to avoid rendering bugs with duplicate player names
- Updated test to verify exit navigates to home

## Test plan
- [ ] Click "Rejouer" → game resets, stays on game screen
- [ ] Click "Quitter" → game resets AND navigates to home
- [ ] Two players with same name → both shown correctly in summary
- [ ] All 25 game-summary tests pass