### PR TITLE
fix: hide summary checkbox for anonymous users (Bug 14.8)

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,7 @@
 
   <div class="content container d-flex gap-1 justify-content-center my-4 mt-2 mb-2">
     <div class="d-flex flex-column gap-2">
-      @if (gameSrv.isNewGame() && playerSrv.getPlayerNumber() > 1 && isPlayersPage()) {
+      @if (gameSrv.isNewGame() && playerSrv.getPlayerNumber() > 1 && isPlayersPage() && !authService.isAnonymous()) {
         <div class="summary-toggle">
           <label class="toggle-switch">
             <input

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,6 +3,7 @@ import { Component, Input, NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { AppComponent } from './app.component';
+import { AuthService } from './services/auth/auth.service';
 import { GameService } from './services/game/game.service';
 import { PlayerHelperService } from './_shared/_helpers/player.helper';
 import { HeaderComponent } from './_shared/_components/header/header.component';
@@ -33,6 +34,7 @@ describe('AppComponent', () => {
     summary: ReturnType<typeof signal<boolean>>;
     isNewGame: jasmine.Spy;
   };
+  let mockAuthService: { isAnonymous: ReturnType<typeof signal<boolean>> };
   let mockPlayerHelperService: jasmine.SpyObj<PlayerHelperService>;
   beforeEach(async () => {
     // Create writable signals for GameService mock
@@ -45,6 +47,10 @@ describe('AppComponent', () => {
       isNewGame: jasmine.createSpy('isNewGame').and.returnValue(true),
     };
 
+    mockAuthService = {
+      isAnonymous: signal<boolean>(false),
+    };
+
     mockPlayerHelperService = jasmine.createSpyObj('PlayerHelperService', ['getPlayerNumber']);
     mockPlayerHelperService.getPlayerNumber.and.returnValue(0);
 
@@ -52,6 +58,7 @@ describe('AppComponent', () => {
       imports: [AppComponent, TranslateModule.forRoot()],
       providers: [
         provideRouter([]),
+        { provide: AuthService, useValue: mockAuthService },
         { provide: GameService, useValue: mockGameService },
         { provide: PlayerHelperService, useValue: mockPlayerHelperService },
       ],
@@ -78,6 +85,7 @@ describe('AppComponent', () => {
     });
 
     it('should inject required services', () => {
+      expect(component.authService).toBeTruthy();
       expect(component.gameSrv).toBeTruthy();
       expect(component.translate).toBeTruthy();
       expect(component.playerSrv).toBeTruthy();
@@ -235,6 +243,28 @@ describe('AppComponent', () => {
 
       const toggle = fixture.nativeElement.querySelector('.summary-toggle');
       expect(toggle).toBeFalsy();
+    });
+
+    it('should hide summary toggle when user is anonymous', () => {
+      spyOn(component, 'isPlayersPage').and.returnValue(true);
+      mockGameService.isNewGame.and.returnValue(true);
+      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
+      mockAuthService.isAnonymous.set(true);
+      fixture.detectChanges();
+
+      const toggle = fixture.nativeElement.querySelector('.summary-toggle');
+      expect(toggle).toBeFalsy();
+    });
+
+    it('should show summary toggle when user is not anonymous', () => {
+      spyOn(component, 'isPlayersPage').and.returnValue(true);
+      mockGameService.isNewGame.and.returnValue(true);
+      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
+      mockAuthService.isAnonymous.set(false);
+      fixture.detectChanges();
+
+      const toggle = fixture.nativeElement.querySelector('.summary-toggle');
+      expect(toggle).toBeTruthy();
     });
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { Router, RouterOutlet } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { environment } from 'src/environments/environment';
 import { PlayerHelperService } from './_shared/_helpers/player.helper';
+import { AuthService } from './services/auth/auth.service';
 import { GameService } from './services/game/game.service';
 import { HeaderComponent } from './_shared/_components/header/header.component';
 import { FooterComponent } from './_shared/_components/footer/footer.component';
@@ -17,6 +18,7 @@ import { FooterComponent } from './_shared/_components/footer/footer.component';
 })
 export class AppComponent {
   private readonly router = inject(Router);
+  readonly authService = inject(AuthService);
   readonly gameSrv = inject(GameService);
   readonly translate = inject(TranslateService);
   readonly playerSrv = inject(PlayerHelperService);


### PR DESCRIPTION
## Summary
- Summary toggle hidden when user is anonymous (Partie rapide)
- AuthService injected in AppComponent, isAnonymous() checked in template
- 2 new tests

## Test plan
- [ ] Partie rapide → /players → no summary checkbox visible
- [ ] Login with account → /players → summary checkbox visible
- [ ] All 870 tests pass