### PR TITLE
fix: password toggle button overlay on auth pages (Bug 14.9)

### DIFF
--- a/src/app/_components/auth/login/login.component.scss
+++ b/src/app/_components/auth/login/login.component.scss
@@ -59,13 +59,18 @@
   .input-group .btn {
     border-left: none;
     border-color: #ced4da;
+    background-color: transparent;
+    color: #6c757d;
+    z-index: 3;
 
     &:hover {
       background-color: #f8f9fa;
+      color: #495057;
     }
 
     &:focus {
       box-shadow: none;
+      background-color: transparent;
     }
   }
 

--- a/src/app/_components/auth/register/register.component.scss
+++ b/src/app/_components/auth/register/register.component.scss
@@ -70,14 +70,19 @@
 
     .btn-outline-secondary {
       border-left: none;
-      background-color: #f8f9fa;
+      background-color: transparent;
+      border-color: #dee2e6;
+      color: #6c757d;
+      z-index: 3;
 
       &:hover {
-        background-color: #e9ecef;
+        background-color: #f8f9fa;
+        color: #495057;
       }
 
       &:focus {
         box-shadow: none;
+        background-color: transparent;
       }
     }
   }


### PR DESCRIPTION
## Summary
- Password toggle button background changed to transparent (was white overlay)
- z-index added for proper layering
- Applied to both login and register pages

## Test plan
- [ ] Register page on mobile → password toggle doesn't overlap input
- [ ] Login page → same fix applied
- [ ] Toggle still works (show/hide password)
- [ ] All 868 tests pass