### PR TITLE
feat: backend-first game sessions with auto solo room (Story 12.8)

### DIFF
--- a/src/app/_components/auth/login/login.component.ts
+++ b/src/app/_components/auth/login/login.component.ts
@@ -5,6 +5,7 @@ import { Router, RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { AuthService } from '../../../services/auth/auth.service';
 import { GameService } from '../../../services/game/game.service';
+import { SoloRoomService } from '../../../services/solo-room/solo-room.service';
 
 /**
  * LoginComponent - Authentication page for Ketal
@@ -27,6 +28,7 @@ export class LoginComponent implements OnInit {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   private readonly gameService = inject(GameService);
+  private readonly soloRoomService = inject(SoloRoomService);
 
   /** Reactive form for email/password login */
   readonly loginForm = new FormGroup({
@@ -105,9 +107,10 @@ export class LoginComponent implements OnInit {
   }
 
   /**
-   * Navigate to appropriate page after login
+   * Navigate to appropriate page after login.
    * If pendingSummary flag is set, navigates to /game and shows summary.
-   * Otherwise goes to /game if a game is in progress, or /players.
+   * Checks for active KetalSession to resume, otherwise starts background
+   * solo room creation and navigates to /players.
    */
   private async navigateAfterLogin(): Promise<void> {
     if (this.authService.consumePendingSummary()) {
@@ -115,8 +118,17 @@ export class LoginComponent implements OnInit {
       this.gameService.setStatus(3);
       return;
     }
-    const route = this.gameService.isGameStarted() ? '/game' : '/players';
-    await this.router.navigate([route]);
+
+    // Check for active session to resume
+    const activeSession = await this.soloRoomService.checkActiveSession();
+    if (activeSession) {
+      await this.router.navigate(['/game']);
+      return;
+    }
+
+    // Start background solo room creation while user adds players
+    this.soloRoomService.startBackgroundRoomCreation();
+    await this.router.navigate(['/players']);
   }
 
   /**

--- a/src/app/_components/auth/register/register.component.ts
+++ b/src/app/_components/auth/register/register.component.ts
@@ -12,6 +12,7 @@ import { Router, RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { AuthService } from '../../../services/auth/auth.service';
 import { GameService } from '../../../services/game/game.service';
+import { SoloRoomService } from '../../../services/solo-room/solo-room.service';
 
 /**
  * RegisterComponent - User registration page for Ketal
@@ -31,6 +32,7 @@ export class RegisterComponent {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   private readonly gameService = inject(GameService);
+  private readonly soloRoomService = inject(SoloRoomService);
 
   /** Reactive form for registration with password match validation */
   readonly registerForm = new FormGroup(
@@ -101,9 +103,10 @@ export class RegisterComponent {
   }
 
   /**
-   * Navigate to appropriate page after registration
+   * Navigate to appropriate page after registration.
    * If pendingSummary flag is set, navigates to /game and shows summary.
-   * Otherwise goes to /game if a game is in progress, or /players.
+   * Checks for active KetalSession to resume, otherwise starts background
+   * solo room creation and navigates to /players.
    */
   private async navigateAfterRegistration(): Promise<void> {
     if (this.authService.consumePendingSummary()) {
@@ -111,8 +114,17 @@ export class RegisterComponent {
       this.gameService.setStatus(3);
       return;
     }
-    const route = this.gameService.isGameStarted() ? '/game' : '/players';
-    await this.router.navigate([route]);
+
+    // Check for active session to resume
+    const activeSession = await this.soloRoomService.checkActiveSession();
+    if (activeSession) {
+      await this.router.navigate(['/game']);
+      return;
+    }
+
+    // Start background solo room creation while user adds players
+    this.soloRoomService.startBackgroundRoomCreation();
+    await this.router.navigate(['/players']);
   }
 
   /**

--- a/src/app/_shared/_components/footer/footer.component.spec.ts
+++ b/src/app/_shared/_components/footer/footer.component.spec.ts
@@ -10,7 +10,9 @@ import {
   createMockAuthService,
   createMockGameService,
   createMockPlayerHelperService,
+  createMockSoloRoomService,
 } from '../../../testing/test-helpers';
+import { SoloRoomService } from '../../../services/solo-room/solo-room.service';
 import { Game } from '../../_models/game.model';
 import { PlayerModel } from '../../_models/player.model';
 import { CardType } from '../../_models/card-type.model';
@@ -21,6 +23,7 @@ describe('FooterComponent', () => {
   let fixture: ComponentFixture<FooterComponent>;
   let mockGameService: ReturnType<typeof createMockGameService>;
   let mockAuthService: ReturnType<typeof createMockAuthService>;
+  let mockSoloRoomService: ReturnType<typeof createMockSoloRoomService>;
   let mockPlayerHelperService: jasmine.SpyObj<PlayerHelperService>;
   let mockRouter: jasmine.SpyObj<Router>;
 
@@ -48,6 +51,7 @@ describe('FooterComponent', () => {
   beforeEach(async () => {
     mockGameService = createMockGameService();
     mockAuthService = createMockAuthService();
+    mockSoloRoomService = createMockSoloRoomService();
     mockPlayerHelperService = createMockPlayerHelperService();
     mockRouter = jasmine.createSpyObj('Router', ['navigate'], { url: '/game' });
 
@@ -66,6 +70,7 @@ describe('FooterComponent', () => {
       providers: [
         { provide: AuthService, useValue: mockAuthService },
         { provide: GameService, useValue: mockGameService },
+        { provide: SoloRoomService, useValue: mockSoloRoomService },
         { provide: PlayerHelperService, useValue: mockPlayerHelperService },
         { provide: Router, useValue: mockRouter },
       ],

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -5,6 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { FontAwesomeIconsModule } from '../../../font-awesome.module';
 import { AuthService } from '../../../services/auth/auth.service';
 import { GameService } from '../../../services/game/game.service';
+import { SoloRoomService } from '../../../services/solo-room/solo-room.service';
 import { PlayerHelperService } from '../../_helpers/player.helper';
 import { CardType } from '../../_models/card-type.model';
 import { DrinkChoiceEnum } from '../../_models/enums/drink_choice.enum';
@@ -36,6 +37,7 @@ export class FooterComponent {
   private readonly router = inject(Router);
   private readonly authService = inject(AuthService);
   readonly gameSrv = inject(GameService);
+  private readonly soloRoomService = inject(SoloRoomService);
   readonly playerHelper = inject(PlayerHelperService);
 
   @Input() public withSummaryMode: boolean = false;
@@ -169,6 +171,8 @@ export class FooterComponent {
   }
 
   async beginGame(): Promise<void> {
+    // Await background solo room creation (no-op if already ready or local mode)
+    await this.soloRoomService.awaitRoom();
     await this.gameSrv.beginGame(this.withSummaryMode);
     this.router.navigate(['/game']);
   }

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -46,6 +46,9 @@ export class FooterComponent {
 
   readonly cardSlots = [0, 1, 2, 3, 4, 5];
 
+  /** Guard flag to prevent double-click on beginGame */
+  private _beginGameInProgress = false;
+
   /** Reference card for Turn 2 (the card drawn in Turn 1 for the active player) */
   getReferenceCard(): CardType | null {
     const activePlayer = this.gameSrv.activePlayer();
@@ -171,10 +174,19 @@ export class FooterComponent {
   }
 
   async beginGame(): Promise<void> {
-    // Await background solo room creation (no-op if already ready or local mode)
-    await this.soloRoomService.awaitRoom();
-    await this.gameSrv.beginGame(this.withSummaryMode);
-    this.router.navigate(['/game']);
+    if (this._beginGameInProgress) {
+      return;
+    }
+    this._beginGameInProgress = true;
+
+    try {
+      // Await background solo room creation (no-op if already ready or local mode)
+      await this.soloRoomService.awaitRoom();
+      await this.gameSrv.beginGame(this.withSummaryMode);
+      this.router.navigate(['/game']);
+    } finally {
+      this._beginGameInProgress = false;
+    }
   }
 
   private delay(ms: number): Promise<void> {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,9 +4,12 @@ import { provideRouter } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { AppComponent } from './app.component';
 import { GameService } from './services/game/game.service';
+import { AuthService } from './services/auth/auth.service';
+import { SoloRoomService } from './services/solo-room/solo-room.service';
 import { PlayerHelperService } from './_shared/_helpers/player.helper';
 import { HeaderComponent } from './_shared/_components/header/header.component';
 import { FooterComponent } from './_shared/_components/footer/footer.component';
+import { createMockAuthService, createMockSoloRoomService } from './testing/test-helpers';
 
 // Stub components to replace actual child components
 @Component({
@@ -32,8 +35,11 @@ describe('AppComponent', () => {
     withSummaryMode: ReturnType<typeof signal<boolean>>;
     summary: ReturnType<typeof signal<boolean>>;
     isNewGame: jasmine.Spy;
+    handleReconnection: jasmine.Spy;
   };
   let mockPlayerHelperService: jasmine.SpyObj<PlayerHelperService>;
+  let mockAuthService: ReturnType<typeof createMockAuthService>;
+  let mockSoloRoomService: ReturnType<typeof createMockSoloRoomService>;
   beforeEach(async () => {
     // Create writable signals for GameService mock
     const withSummaryModeSignal = signal<boolean>(false);
@@ -43,10 +49,13 @@ describe('AppComponent', () => {
       withSummaryMode: withSummaryModeSignal,
       summary: summarySignal,
       isNewGame: jasmine.createSpy('isNewGame').and.returnValue(true),
+      handleReconnection: jasmine.createSpy('handleReconnection').and.resolveTo(undefined),
     };
 
     mockPlayerHelperService = jasmine.createSpyObj('PlayerHelperService', ['getPlayerNumber']);
     mockPlayerHelperService.getPlayerNumber.and.returnValue(0);
+    mockAuthService = createMockAuthService();
+    mockSoloRoomService = createMockSoloRoomService();
 
     await TestBed.configureTestingModule({
       imports: [AppComponent, TranslateModule.forRoot()],
@@ -54,6 +63,8 @@ describe('AppComponent', () => {
         provideRouter([]),
         { provide: GameService, useValue: mockGameService },
         { provide: PlayerHelperService, useValue: mockPlayerHelperService },
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: SoloRoomService, useValue: mockSoloRoomService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,12 @@
-import { Component, computed, Signal, inject } from '@angular/core';
+import { Component, computed, OnInit, Signal, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterOutlet } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { environment } from 'src/environments/environment';
 import { PlayerHelperService } from './_shared/_helpers/player.helper';
 import { GameService } from './services/game/game.service';
+import { AuthService } from './services/auth/auth.service';
+import { SoloRoomService } from './services/solo-room/solo-room.service';
 import { HeaderComponent } from './_shared/_components/header/header.component';
 import { FooterComponent } from './_shared/_components/footer/footer.component';
 
@@ -15,11 +17,13 @@ import { FooterComponent } from './_shared/_components/footer/footer.component';
   standalone: true,
   imports: [FormsModule, RouterOutlet, TranslateModule, HeaderComponent, FooterComponent],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   private readonly router = inject(Router);
   readonly gameSrv = inject(GameService);
   readonly translate = inject(TranslateService);
   readonly playerSrv = inject(PlayerHelperService);
+  private readonly authService = inject(AuthService);
+  private readonly soloRoomService = inject(SoloRoomService);
 
   readonly withSummaryMode: Signal<boolean>;
 
@@ -38,6 +42,26 @@ export class AppComponent {
       const gameSummary = this.gameSrv.summary();
       return this.playerSrv.getPlayerNumber() > 1 ? summaryMode || gameSummary : summaryMode;
     });
+  }
+
+  /**
+   * On init, check for active room + session to resume.
+   * If found, restore game state and navigate to /game.
+   */
+  async ngOnInit(): Promise<void> {
+    try {
+      await this.authService.init();
+
+      if (this.authService.isLoggedIn()) {
+        const activeSession = await this.soloRoomService.checkActiveSession();
+        if (activeSession) {
+          await this.gameSrv.handleReconnection(activeSession.$id);
+          await this.router.navigate(['/game']);
+        }
+      }
+    } catch {
+      // Auth init or session check failed, continue normally
+    }
   }
 
   onSummaryModeCheckChange(event: Event): void {

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -68,7 +68,20 @@ export class AuthService {
    * If no valid session exists or Appwrite is unavailable, the user will remain null.
    * Uses a timeout to prevent blocking when backend is unreachable.
    */
+  /** Cached init promise to ensure idempotent calls */
+  private _initPromise: Promise<void> | null = null;
+
   async init(): Promise<void> {
+    // Return cached promise if already initializing/initialized (idempotent)
+    if (this._initPromise) {
+      return this._initPromise;
+    }
+
+    this._initPromise = this._doInit();
+    return this._initPromise;
+  }
+
+  private async _doInit(): Promise<void> {
     this._isLoading.set(true);
     try {
       // Add timeout to prevent blocking when Appwrite is unavailable

--- a/src/app/services/game/game.service.spec.ts
+++ b/src/app/services/game/game.service.spec.ts
@@ -16,10 +16,12 @@ import {
   createMockKetalSessionService,
   createMockMemberService,
   createMockRealtimeService,
+  createMockSoloRoomService,
   createMockGameRoom,
   createMockKetalSession,
 } from '../../testing/test-helpers';
 import { RealtimeService } from '../realtime/realtime.service';
+import { SoloRoomService } from '../solo-room/solo-room.service';
 import { Game } from '../../_shared/_models/game.model';
 import { PlayerModel } from '../../_shared/_models/player.model';
 import { CardType } from '../../_shared/_models/card-type.model';
@@ -99,6 +101,7 @@ describe('GameService', () => {
   let mockKetalSessionService: ReturnType<typeof createMockKetalSessionService>;
   let mockMemberService: ReturnType<typeof createMockMemberService>;
   let mockRealtimeService: ReturnType<typeof createMockRealtimeService>;
+  let mockSoloRoomService: ReturnType<typeof createMockSoloRoomService>;
 
   beforeEach(() => {
     localStorage.removeItem('ketal_summary_mode');
@@ -110,6 +113,7 @@ describe('GameService', () => {
     mockKetalSessionService = createMockKetalSessionService();
     mockMemberService = createMockMemberService();
     mockRealtimeService = createMockRealtimeService();
+    mockSoloRoomService = createMockSoloRoomService();
 
     TestBed.configureTestingModule({
       providers: [
@@ -122,6 +126,7 @@ describe('GameService', () => {
         { provide: KetalSessionService, useValue: mockKetalSessionService },
         { provide: MemberService, useValue: mockMemberService },
         { provide: RealtimeService, useValue: mockRealtimeService },
+        { provide: SoloRoomService, useValue: mockSoloRoomService },
       ],
     });
     service = TestBed.inject(GameService);
@@ -148,6 +153,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       const newService = TestBed.inject(GameService);
@@ -168,6 +178,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       const newService = TestBed.inject(GameService);
@@ -662,6 +677,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       return TestBed.inject(GameService);
@@ -1048,6 +1068,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       return TestBed.inject(GameService);
@@ -1091,6 +1116,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       return TestBed.inject(GameService);
@@ -1194,6 +1224,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       return TestBed.inject(GameService);
@@ -1346,6 +1381,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       return TestBed.inject(GameService);
@@ -1535,6 +1575,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       return TestBed.inject(GameService);
@@ -1667,6 +1712,11 @@ describe('GameService', () => {
           { provide: CardService, useValue: mockCardService },
           { provide: PlayerHelperService, useValue: mockPlayerHelperService },
           { provide: CardDeckHelperService, useValue: mockCardDeckHelperService },
+          { provide: RoomService, useValue: mockRoomService },
+          { provide: KetalSessionService, useValue: mockKetalSessionService },
+          { provide: MemberService, useValue: mockMemberService },
+          { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       return TestBed.inject(GameService);
@@ -2611,6 +2661,7 @@ describe('GameService', () => {
           { provide: KetalSessionService, useValue: mockKetalSessionService },
           { provide: MemberService, useValue: mockMemberService },
           { provide: RealtimeService, useValue: mockRealtimeService },
+          { provide: SoloRoomService, useValue: mockSoloRoomService },
         ],
       });
       return TestBed.inject(GameService);

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -16,6 +16,7 @@ import { LocalService } from '../local/local.service';
 import { MemberService } from '../member/member.service';
 import { RealtimeService } from '../realtime/realtime.service';
 import { RoomService } from '../room/room.service';
+import { SoloRoomService } from '../solo-room/solo-room.service';
 import { mapGameToSessionUpdate, mapPlayerModelToKetalPlayer, mapSessionToGame } from './game-mappers';
 
 /** Game mode type: local (localStorage) or room (Appwrite) */
@@ -33,6 +34,7 @@ export class GameService {
   private readonly ketalSessionService = inject(KetalSessionService);
   private readonly memberService = inject(MemberService);
   private readonly realtimeService = inject(RealtimeService);
+  private readonly soloRoomService = inject(SoloRoomService);
   private readonly destroyRef = inject(DestroyRef);
 
   /**
@@ -491,6 +493,10 @@ export class GameService {
     // Clear session ID — game is truly ending
     this.activeSessionId = null;
     this._pendingSessionUpdate = null;
+
+    // Clean up solo room state and leave room
+    this.soloRoomService.reset();
+    this.roomService.leaveRoom();
 
     this.updateGame((game) => {
       game.givingCards = [];

--- a/src/app/services/realtime/realtime.service.ts
+++ b/src/app/services/realtime/realtime.service.ts
@@ -28,7 +28,7 @@ export interface GameRoom {
   currentSessionId: string | null;
   status: 'idle' | 'playing';
   hostMemberId: string;
-  mode: 'local' | 'multiplayer';
+  mode: 'local' | 'multiplayer' | 'solo';
   maxPlayers: number;
   gamesPlayed: number;
 }

--- a/src/app/services/room/room.service.ts
+++ b/src/app/services/room/room.service.ts
@@ -16,7 +16,7 @@ export type RoomStatus = 'idle' | 'playing';
 /**
  * Room mode enum for type safety
  */
-export type RoomMode = 'local' | 'multiplayer';
+export type RoomMode = 'local' | 'multiplayer' | 'solo';
 
 /**
  * GameRoom interface representing a game room document in Appwrite
@@ -85,6 +85,16 @@ export class RoomService {
 
   /** Public readonly signal for current room state */
   readonly currentRoom = this._currentRoom.asReadonly();
+
+  /**
+   * Create a solo room for backend-first game sessions.
+   * Auto-generates a name, uses 'solo' mode, no invite needed.
+   * Called in background after login while user adds player names.
+   */
+  async createSoloRoom(): Promise<GameRoom> {
+    const name = `Solo-${Date.now()}`;
+    return this.createRoom(name, 'solo', 10);
+  }
 
   /**
    * Create a new game room

--- a/src/app/services/solo-room/solo-room.service.spec.ts
+++ b/src/app/services/solo-room/solo-room.service.spec.ts
@@ -1,0 +1,208 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { SoloRoomService } from './solo-room.service';
+import { RoomService, GameRoom } from '../room/room.service';
+import { KetalSessionService, KetalSession } from '../ketal-session/ketal-session.service';
+import {
+  createMockRoomService,
+  createMockKetalSessionService,
+  createMockGameRoom,
+  createMockKetalSession,
+} from '../../testing/test-helpers';
+
+describe('SoloRoomService', () => {
+  let service: SoloRoomService;
+  let mockRoomService: ReturnType<typeof createMockRoomService>;
+  let mockKetalSessionService: ReturnType<typeof createMockKetalSessionService>;
+
+  beforeEach(() => {
+    mockRoomService = createMockRoomService();
+    mockKetalSessionService = createMockKetalSessionService();
+
+    TestBed.configureTestingModule({
+      providers: [
+        SoloRoomService,
+        { provide: RoomService, useValue: mockRoomService },
+        { provide: KetalSessionService, useValue: mockKetalSessionService },
+      ],
+    });
+
+    service = TestBed.inject(SoloRoomService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('initial state', () => {
+    it('should have localModeFallback set to false', () => {
+      expect(service.localModeFallback()).toBeFalse();
+    });
+
+    it('should have isCreating set to false', () => {
+      expect(service.isCreating()).toBeFalse();
+    });
+  });
+
+  describe('startBackgroundRoomCreation', () => {
+    it('should call createSoloRoom on RoomService', () => {
+      const mockRoom = createMockGameRoom({ mode: 'solo' });
+      mockRoomService.createSoloRoom = jasmine.createSpy('createSoloRoom').and.resolveTo(mockRoom);
+
+      service.startBackgroundRoomCreation();
+
+      expect(mockRoomService.createSoloRoom).toHaveBeenCalled();
+    });
+
+    it('should set isCreating to true while creating', () => {
+      const mockRoom = createMockGameRoom({ mode: 'solo' });
+      mockRoomService.createSoloRoom = jasmine.createSpy('createSoloRoom').and.resolveTo(mockRoom);
+
+      service.startBackgroundRoomCreation();
+
+      expect(service.isCreating()).toBeTrue();
+    });
+
+    it('should not create if a room already exists', () => {
+      mockRoomService.currentRoom.set(createMockGameRoom());
+      mockRoomService.createSoloRoom = jasmine.createSpy('createSoloRoom');
+
+      service.startBackgroundRoomCreation();
+
+      expect(mockRoomService.createSoloRoom).not.toHaveBeenCalled();
+    });
+
+    it('should not create if already in progress', () => {
+      const mockRoom = createMockGameRoom({ mode: 'solo' });
+      mockRoomService.createSoloRoom = jasmine.createSpy('createSoloRoom').and.resolveTo(mockRoom);
+
+      service.startBackgroundRoomCreation();
+      service.startBackgroundRoomCreation();
+
+      expect(mockRoomService.createSoloRoom).toHaveBeenCalledTimes(1);
+    });
+
+    it('should set localModeFallback on failure', async () => {
+      mockRoomService.createSoloRoom = jasmine
+        .createSpy('createSoloRoom')
+        .and.rejectWith(new Error('Network error'));
+
+      service.startBackgroundRoomCreation();
+
+      // Wait for the promise to settle
+      await service.awaitRoom();
+
+      expect(service.localModeFallback()).toBeTrue();
+    });
+  });
+
+  describe('awaitRoom', () => {
+    it('should return the room when creation succeeds', async () => {
+      const mockRoom = createMockGameRoom({ mode: 'solo' });
+      mockRoomService.createSoloRoom = jasmine.createSpy('createSoloRoom').and.resolveTo(mockRoom);
+
+      service.startBackgroundRoomCreation();
+      const result = await service.awaitRoom();
+
+      expect(result).toEqual(mockRoom);
+    });
+
+    it('should return null when creation fails', async () => {
+      mockRoomService.createSoloRoom = jasmine
+        .createSpy('createSoloRoom')
+        .and.rejectWith(new Error('Network error'));
+
+      service.startBackgroundRoomCreation();
+      const result = await service.awaitRoom();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when no creation was started and no room exists', async () => {
+      const result = await service.awaitRoom();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return existing room when no creation was started', async () => {
+      const mockRoom = createMockGameRoom();
+      mockRoomService.currentRoom.set(mockRoom);
+
+      const result = await service.awaitRoom();
+
+      expect(result).toEqual(mockRoom);
+    });
+
+    it('should return null when localModeFallback is set', async () => {
+      mockRoomService.createSoloRoom = jasmine
+        .createSpy('createSoloRoom')
+        .and.rejectWith(new Error('Failed'));
+
+      service.startBackgroundRoomCreation();
+
+      // Wait for promise to settle
+      try {
+        await service.awaitRoom();
+      } catch {
+        // Expected
+      }
+
+      // Now the fallback should be set
+      const result = await service.awaitRoom();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('checkActiveSession', () => {
+    it('should return current session if active', async () => {
+      const mockSession = createMockKetalSession({ status: 'playing' });
+      mockKetalSessionService.currentSession.set(mockSession);
+
+      const result = await service.checkActiveSession();
+
+      expect(result).toEqual(mockSession);
+    });
+
+    it('should return null if current session is finished', async () => {
+      const mockSession = createMockKetalSession({ status: 'finished' });
+      mockKetalSessionService.currentSession.set(mockSession);
+
+      const result = await service.checkActiveSession();
+
+      expect(result).toBeNull();
+    });
+
+    it('should fetch session from room if room has currentSessionId', async () => {
+      const mockSession = createMockKetalSession({ status: 'playing' });
+      const mockRoom = createMockGameRoom({ currentSessionId: 'session-123' });
+      mockRoomService.currentRoom.set(mockRoom);
+      mockKetalSessionService.getSession.and.resolveTo(mockSession);
+
+      const result = await service.checkActiveSession();
+
+      expect(mockKetalSessionService.getSession).toHaveBeenCalledWith('session-123');
+      expect(result).toEqual(mockSession);
+    });
+
+    it('should return null if no current session and no room', async () => {
+      const result = await service.checkActiveSession();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset all state', async () => {
+      const mockRoom = createMockGameRoom({ mode: 'solo' });
+      mockRoomService.createSoloRoom = jasmine.createSpy('createSoloRoom').and.resolveTo(mockRoom);
+
+      service.startBackgroundRoomCreation();
+      await service.awaitRoom();
+
+      service.reset();
+
+      expect(service.localModeFallback()).toBeFalse();
+      expect(service.isCreating()).toBeFalse();
+    });
+  });
+});

--- a/src/app/services/solo-room/solo-room.service.spec.ts
+++ b/src/app/services/solo-room/solo-room.service.spec.ts
@@ -113,6 +113,8 @@ describe('SoloRoomService', () => {
         .and.rejectWith(new Error('Network error'));
 
       service.startBackgroundRoomCreation();
+
+      // awaitRoom returns null because localModeFallback is set after failure
       const result = await service.awaitRoom();
 
       expect(result).toBeNull();
@@ -140,12 +142,8 @@ describe('SoloRoomService', () => {
 
       service.startBackgroundRoomCreation();
 
-      // Wait for promise to settle
-      try {
-        await service.awaitRoom();
-      } catch {
-        // Expected
-      }
+      // Wait for promise to settle (no longer throws since error is swallowed)
+      await service.awaitRoom();
 
       // Now the fallback should be set
       const result = await service.awaitRoom();

--- a/src/app/services/solo-room/solo-room.service.ts
+++ b/src/app/services/solo-room/solo-room.service.ts
@@ -1,0 +1,127 @@
+import { inject, Injectable, signal } from '@angular/core';
+import { GameRoom, RoomService } from '../room/room.service';
+import { KetalSession, KetalSessionService } from '../ketal-session/ketal-session.service';
+
+/**
+ * SoloRoomService - Manages background solo room creation for backend-first sessions
+ *
+ * After login (any method), a solo room is auto-created in the background while
+ * the user adds player names. When "Debuter la Grosse Guinze" is clicked,
+ * the room Promise is awaited to create a KetalSession.
+ *
+ * Uses Angular 19 patterns: injectable, signals, inject().
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SoloRoomService {
+  private readonly roomService = inject(RoomService);
+  private readonly ketalSessionService = inject(KetalSessionService);
+
+  /** Promise for the background solo room creation */
+  private _roomPromise: Promise<GameRoom> | null = null;
+
+  /** Signal indicating if room creation failed (triggers local mode fallback) */
+  private readonly _localModeFallback = signal(false);
+
+  /** Public readonly signal for local mode fallback state */
+  readonly localModeFallback = this._localModeFallback.asReadonly();
+
+  /** Signal indicating if background room creation is in progress */
+  private readonly _isCreating = signal(false);
+
+  /** Public readonly signal for creation state */
+  readonly isCreating = this._isCreating.asReadonly();
+
+  /**
+   * Start background solo room creation.
+   * Stores the Promise so it can be awaited later when the game begins.
+   * If creation fails, sets localModeFallback flag.
+   */
+  startBackgroundRoomCreation(): void {
+    // Don't create if already in progress or if a room already exists
+    if (this._roomPromise || this.roomService.currentRoom()) {
+      return;
+    }
+
+    this._localModeFallback.set(false);
+    this._isCreating.set(true);
+
+    this._roomPromise = this.roomService.createSoloRoom().catch((error) => {
+      console.warn('[SoloRoomService] Background room creation failed, falling back to local mode:', error);
+      this._localModeFallback.set(true);
+      this._isCreating.set(false);
+      throw error;
+    });
+
+    this._roomPromise
+      .then(() => {
+        this._isCreating.set(false);
+      })
+      .catch(() => {
+        // Error already handled above
+      });
+  }
+
+  /**
+   * Await the background room creation Promise.
+   * Returns the room if successful, null if failed (local mode fallback).
+   */
+  async awaitRoom(): Promise<GameRoom | null> {
+    if (this._localModeFallback()) {
+      return null;
+    }
+
+    if (!this._roomPromise) {
+      // No room creation was started; check if room already exists
+      const existingRoom = this.roomService.currentRoom();
+      if (existingRoom) {
+        return existingRoom;
+      }
+      return null;
+    }
+
+    try {
+      return await this._roomPromise;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Check if there is an active session to resume.
+   * Returns the session if found, null otherwise.
+   */
+  async checkActiveSession(): Promise<KetalSession | null> {
+    const currentSession = this.ketalSessionService.currentSession();
+    if (currentSession && currentSession.status !== 'finished') {
+      return currentSession;
+    }
+
+    // Check if current room has an active session
+    const room = this.roomService.currentRoom();
+    if (room?.currentSessionId) {
+      try {
+        const session = await this.ketalSessionService.getSession(room.currentSessionId);
+        if (session && session.status !== 'finished') {
+          this.ketalSessionService.setCurrentSession(session);
+          return session;
+        }
+      } catch {
+        // Session not found, continue
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Reset the solo room service state.
+   * Called when game ends or user leaves.
+   */
+  reset(): void {
+    this._roomPromise = null;
+    this._localModeFallback.set(false);
+    this._isCreating.set(false);
+  }
+}

--- a/src/app/services/solo-room/solo-room.service.ts
+++ b/src/app/services/solo-room/solo-room.service.ts
@@ -47,19 +47,17 @@ export class SoloRoomService {
     this._localModeFallback.set(false);
     this._isCreating.set(true);
 
-    this._roomPromise = this.roomService.createSoloRoom().catch((error) => {
-      console.warn('[SoloRoomService] Background room creation failed, falling back to local mode:', error);
-      this._localModeFallback.set(true);
-      this._isCreating.set(false);
-      throw error;
-    });
-
-    this._roomPromise
-      .then(() => {
+    this._roomPromise = this.roomService.createSoloRoom()
+      .then((room) => {
         this._isCreating.set(false);
+        return room;
       })
-      .catch(() => {
-        // Error already handled above
+      .catch((error) => {
+        console.warn('[SoloRoomService] Background room creation failed, falling back to local mode:', error);
+        this._localModeFallback.set(true);
+        this._isCreating.set(false);
+        this._roomPromise = null; // Allow retry
+        throw error;
       });
   }
 

--- a/src/app/services/solo-room/solo-room.service.ts
+++ b/src/app/services/solo-room/solo-room.service.ts
@@ -19,7 +19,7 @@ export class SoloRoomService {
   private readonly ketalSessionService = inject(KetalSessionService);
 
   /** Promise for the background solo room creation */
-  private _roomPromise: Promise<GameRoom> | null = null;
+  private _roomPromise: Promise<GameRoom | null> | null = null;
 
   /** Signal indicating if room creation failed (triggers local mode fallback) */
   private readonly _localModeFallback = signal(false);
@@ -57,7 +57,7 @@ export class SoloRoomService {
         this._localModeFallback.set(true);
         this._isCreating.set(false);
         this._roomPromise = null; // Allow retry
-        throw error;
+        return null; // Swallow error to avoid unhandled promise rejection
       });
   }
 

--- a/src/app/testing/test-helpers.ts
+++ b/src/app/testing/test-helpers.ts
@@ -10,6 +10,7 @@ import { RoomService, GameRoom } from '../services/room/room.service';
 import { KetalSessionService, KetalSession } from '../services/ketal-session/ketal-session.service';
 import { MemberService, GameMember } from '../services/member/member.service';
 import { RealtimeService } from '../services/realtime/realtime.service';
+import { SoloRoomService } from '../services/solo-room/solo-room.service';
 import { Game } from '../_shared/_models/game.model';
 import { PlayerModel } from '../_shared/_models/player.model';
 import { CardType } from '../_shared/_models/card-type.model';
@@ -28,7 +29,7 @@ export function createMockAuthService(): jasmine.SpyObj<AuthService> & {
 
   const mock = jasmine.createSpyObj(
     'AuthService',
-    ['init', 'signUp', 'loginWithEmail', 'signInWithGoogle', 'logout', 'createAnonymousSession', 'getOrCreateSession'],
+    ['init', 'signUp', 'loginWithEmail', 'signInWithGoogle', 'logout', 'createAnonymousSession', 'getOrCreateSession', 'consumePendingSummary'],
     {
       currentUser: signal(null),
       isLoggedIn: mockIsLoggedIn,
@@ -42,6 +43,7 @@ export function createMockAuthService(): jasmine.SpyObj<AuthService> & {
   mock.loginWithEmail.and.resolveTo(undefined);
   mock.logout.and.resolveTo(undefined);
   mock.createAnonymousSession.and.resolveTo(undefined);
+  mock.consumePendingSummary.and.returnValue(false);
 
   return mock as jasmine.SpyObj<AuthService> & {
     isLoggedIn: WritableSignal<boolean>;
@@ -192,6 +194,7 @@ export function createMockRoomService(): jasmine.SpyObj<RoomService> & {
     'RoomService',
     [
       'createRoom',
+      'createSoloRoom',
       'joinRoom',
       'leaveRoom',
       'deleteRoom',
@@ -209,6 +212,7 @@ export function createMockRoomService(): jasmine.SpyObj<RoomService> & {
 
   // Setup default return values
   mock.createRoom.and.resolveTo(null);
+  mock.createSoloRoom.and.resolveTo(null);
   mock.joinRoom.and.resolveTo(null);
   mock.leaveRoom.and.resolveTo(undefined);
   mock.deleteRoom.and.resolveTo(undefined);
@@ -360,4 +364,32 @@ export function createMockRealtimeService(): jasmine.SpyObj<RealtimeService> {
   mock.getActiveSubscriptionIds.and.returnValue([]);
 
   return mock;
+}
+
+/**
+ * Creates a mock SoloRoomService for testing
+ */
+export function createMockSoloRoomService(): jasmine.SpyObj<SoloRoomService> & {
+  localModeFallback: WritableSignal<boolean>;
+  isCreating: WritableSignal<boolean>;
+} {
+  const mockLocalModeFallback = signal<boolean>(false);
+  const mockIsCreating = signal<boolean>(false);
+
+  const mock = jasmine.createSpyObj(
+    'SoloRoomService',
+    ['startBackgroundRoomCreation', 'awaitRoom', 'checkActiveSession', 'reset'],
+    {
+      localModeFallback: mockLocalModeFallback,
+      isCreating: mockIsCreating,
+    }
+  );
+
+  mock.awaitRoom.and.resolveTo(null);
+  mock.checkActiveSession.and.resolveTo(null);
+
+  return mock as jasmine.SpyObj<SoloRoomService> & {
+    localModeFallback: WritableSignal<boolean>;
+    isCreating: WritableSignal<boolean>;
+  };
 }


### PR DESCRIPTION
## Summary
- New SoloRoomService: background solo room creation after login
- Post-login routing: active session → /game, no session → /players
- "Débuter" awaits room then creates KetalSession (room mode)
- Offline fallback: transparent local mode if backend unreachable
- Resume active session on app reload
- Auth init idempotent + room creation retry on failure (review fixes)

## Test plan
- [ ] Partie rapide → add players → Débuter → game in room mode
- [ ] Close browser → reopen → game resumes
- [ ] Kill backend → game falls back to local mode
- [ ] All 879 tests pass