### PR TITLE
fix: reset sip display between Phase 1 turns (Bug 14.7)

### DIFF
--- a/src/app/_components/players/player-card/player-card.component.html
+++ b/src/app/_components/players/player-card/player-card.component.html
@@ -32,6 +32,13 @@
           </div>
         }
       </div>
+      @if (lastTurnSips() > 0) {
+        <div class="text-center mt-1">
+          <span class="badge bg-warning text-dark per-turn-sips">
+            +{{ lastTurnSips() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
+          </span>
+        </div>
+      }
     </div>
   </div>
 </div>

--- a/src/app/_components/players/player-card/player-card.component.scss
+++ b/src/app/_components/players/player-card/player-card.component.scss
@@ -25,3 +25,13 @@
   opacity: 0.7;
   transition: all 0.3s ease;
 }
+
+.per-turn-sips {
+  font-size: 0.75rem;
+  animation: fadeIn 0.3s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/app/_components/players/player-card/player-card.component.spec.ts
+++ b/src/app/_components/players/player-card/player-card.component.spec.ts
@@ -247,6 +247,43 @@ describe('PlayerCardComponent', () => {
     });
   });
 
+  describe('lastTurnSips', () => {
+    it('should return 0 by default', () => {
+      fixture.detectChanges();
+      expect(component.lastTurnSips()).toBe(0);
+    });
+
+    it('should return value from GameService for this player', () => {
+      mockGameService.getLastTurnSipsForPlayer.and.returnValue(3);
+      fixture.detectChanges();
+
+      expect(component.lastTurnSips()).toBe(3);
+      expect(mockGameService.getLastTurnSipsForPlayer).toHaveBeenCalledWith('1');
+    });
+
+    it('should return 0 when player is falsy', () => {
+      component.player = null as any;
+      expect(component.lastTurnSips()).toBe(0);
+    });
+
+    it('should not display per-turn sips badge when lastTurnSips is 0', () => {
+      mockGameService.getLastTurnSipsForPlayer.and.returnValue(0);
+      fixture.detectChanges();
+
+      const perTurnBadge = fixture.nativeElement.querySelector('.per-turn-sips');
+      expect(perTurnBadge).toBeNull();
+    });
+
+    it('should display per-turn sips badge when lastTurnSips is greater than 0', () => {
+      mockGameService.getLastTurnSipsForPlayer.and.returnValue(2);
+      fixture.detectChanges();
+
+      const perTurnBadge = fixture.nativeElement.querySelector('.per-turn-sips');
+      expect(perTurnBadge).toBeTruthy();
+      expect(perTurnBadge.textContent).toContain('+2');
+    });
+  });
+
   describe('Component lifecycle', () => {
     it('should properly clean up on destroy', () => {
       fixture.detectChanges();

--- a/src/app/_components/players/player-card/player-card.component.ts
+++ b/src/app/_components/players/player-card/player-card.component.ts
@@ -41,6 +41,13 @@ export class PlayerCardComponent implements OnInit {
     return this.player ? this.playerSrv.getSipCnt(this.gameSrv.game(), this.player, true) : 0;
   });
 
+  /** Per-turn sip indicator for Phase 1 - resets when active player changes */
+  readonly lastTurnSips = computed(() => {
+    // Read the signal to establish dependency
+    this.gameSrv.lastTurnSips();
+    return this.player ? this.gameSrv.getLastTurnSipsForPlayer(this.player.id) : 0;
+  });
+
   ngOnInit(): void {
     this.gameSrv.openSipGiveModalEvent$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((player) => {
       if (this.player.id === player.id) {

--- a/src/app/services/game/game.service.spec.ts
+++ b/src/app/services/game/game.service.spec.ts
@@ -1329,6 +1329,86 @@ describe('GameService', () => {
 
       expect(testService.game().phase).toBe(2);
     });
+
+    it('should set lastTurnSips for the active player after picking a card', () => {
+      const player1 = createMockPlayer({
+        id: 'player-1',
+        cards: [],
+        choice: { color: 'red', plus_or_minus: '', in_out: '', suit: '' },
+      });
+      const player2 = createMockPlayer({
+        id: 'player-2',
+        cards: [],
+        choice: { color: '', plus_or_minus: '', in_out: '', suit: '' },
+      });
+      const mockGame = createMockGame({
+        players: [player1, player2],
+        activePlayer: player1,
+        turn: 1,
+      });
+      const testService = createServiceWithGame(mockGame);
+
+      const newCard = createMockCard({ value: '5', suit: 'hearts' });
+      mockCardDeckHelperService.getRandomCard.and.returnValue(newCard);
+      mockPlayerHelperService.getPlayerChoice.and.returnValue(ColorsEnum.Red);
+      mockCardService.isBlackCard.and.returnValue(true);
+      mockCardService.isRedCard.and.returnValue(false);
+
+      testService.pickCard();
+
+      // Player 1 predicted red but got black => 1 sip
+      expect(testService.getLastTurnSipsForPlayer('player-1')).toBe(1);
+      expect(testService.getLastTurnSipsForPlayer('player-2')).toBe(0);
+    });
+
+    it('should clear lastTurnSips when a new round starts (last player picks)', () => {
+      const player = createMockPlayer({
+        id: 'player-1',
+        cards: [],
+        choice: { color: 'red', plus_or_minus: '', in_out: '', suit: '' },
+      });
+      const mockGame = createMockGame({
+        players: [player],
+        activePlayer: player,
+        turn: 1,
+      });
+      const testService = createServiceWithGame(mockGame);
+
+      const newCard = createMockCard({ value: '5', suit: 'hearts' });
+      mockCardDeckHelperService.getRandomCard.and.returnValue(newCard);
+      mockPlayerHelperService.getPlayerChoice.and.returnValue(ColorsEnum.Red);
+      mockCardService.isBlackCard.and.returnValue(true);
+      mockCardService.isRedCard.and.returnValue(false);
+
+      testService.pickCard();
+
+      // Last player picked => new round starts => lastTurnSips cleared
+      expect(testService.getLastTurnSipsForPlayer('player-1')).toBe(0);
+    });
+
+    it('should clear lastTurnSips when entering Phase 2', () => {
+      const player = createMockPlayer({
+        id: 'player-1',
+        cards: [createMockCard(), createMockCard(), createMockCard()],
+        choice: { color: 'red', plus_or_minus: 'plus', in_out: 'in', suit: 'hearts' },
+      });
+      const mockGame = createMockGame({
+        players: [player],
+        activePlayer: player,
+        turn: 4,
+        phase: 1,
+      });
+      const testService = createServiceWithGame(mockGame);
+
+      const newCard = createMockCard();
+      mockCardDeckHelperService.getRandomCard.and.returnValue(newCard);
+      mockPlayerHelperService.getPlayerChoice.and.returnValue('hearts');
+
+      testService.pickCard();
+
+      expect(testService.game().phase).toBe(2);
+      expect(testService.getLastTurnSipsForPlayer('player-1')).toBe(0);
+    });
   });
 
   // ==========================================================================
@@ -1620,6 +1700,15 @@ describe('GameService', () => {
       testService.resetGame();
 
       expect(mockPlayerHelperService.savePlayerToStorage).toHaveBeenCalled();
+    });
+
+    it('should clear lastTurnSips on reset', () => {
+      const mockGame = createMockGame({ status: 2 });
+      const testService = createServiceWithGame(mockGame);
+
+      testService.resetGame();
+
+      expect(testService.getLastTurnSipsForPlayer('player-1')).toBe(0);
     });
   });
 

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -80,6 +80,15 @@ export class GameService {
   readonly givingCards = computed(() => this._game()?.givingCards ?? []);
   readonly summary = computed(() => this._game()?.summary ?? false);
 
+  /**
+   * Per-turn sip indicator for Phase 1.
+   * Tracks the sips from the most recently dealt card per player.
+   * Resets when the active player changes (next player's turn starts).
+   * Map key = player ID, value = sips from the last dealt card.
+   */
+  private readonly _lastTurnSips = signal<Record<string, number>>({});
+  readonly lastTurnSips = this._lastTurnSips.asReadonly();
+
   /** localStorage key for summary mode preference */
   private static readonly SUMMARY_MODE_KEY = 'ketal_summary_mode';
 
@@ -491,6 +500,8 @@ export class GameService {
     // Clear session ID — game is truly ending
     this.activeSessionId = null;
     this._pendingSessionUpdate = null;
+    // Clear per-turn sip indicator
+    this._lastTurnSips.set({});
 
     this.updateGame((game) => {
       game.givingCards = [];
@@ -689,6 +700,13 @@ export class GameService {
 
     const currentCard = this.cardDeckHelperService.getRandomCard();
     this.assignSipsForFirstTurn(currentCard, game.activePlayer.id);
+
+    // Track per-turn sips for the current player before advancing
+    this._lastTurnSips.update((sips) => ({
+      ...sips,
+      [game.activePlayer!.id]: currentCard.sips ?? 0,
+    }));
+
     this.addCardToPlayer(currentCard, game.activePlayer.id);
 
     this.updateGame((g) => {
@@ -700,8 +718,12 @@ export class GameService {
         if (g.turn > 4) {
           g.phase = 2;
           g.activePlayer = undefined;
+          // Clear per-turn sips when entering Phase 2
+          this._lastTurnSips.set({});
         } else {
           g.activePlayer = g.players[0];
+          // Clear per-turn sips when a new round starts
+          this._lastTurnSips.set({});
         }
       } else {
         g.activePlayer = g.players[currentIndex + 1];
@@ -925,6 +947,14 @@ export class GameService {
   private mapPlayersToKetalPlayers(): KetalPlayer[] {
     const players: PlayerModel[] = JSON.parse(this.localSrv.getData('players') as string);
     return players.map((player, index) => mapPlayerModelToKetalPlayer(player, index));
+  }
+
+  /**
+   * Get the per-turn sip count for a player from the most recently dealt card.
+   * Returns 0 if no sips were assigned this turn or the turn has advanced.
+   */
+  getLastTurnSipsForPlayer(playerId: string): number {
+    return this._lastTurnSips()[playerId] ?? 0;
   }
 
   openSipGiveModal(player: PlayerModel): void {

--- a/src/app/testing/test-helpers.ts
+++ b/src/app/testing/test-helpers.ts
@@ -93,6 +93,7 @@ export function createMockGameService(): jasmine.SpyObj<GameService> & {
       'addPlayerSip',
       'updatePlayerGivenSipsFromCard',
       'openSipGiveModal',
+      'getLastTurnSipsForPlayer',
     ],
     {
       withSummaryMode: mockWithSummaryMode,
@@ -108,8 +109,10 @@ export function createMockGameService(): jasmine.SpyObj<GameService> & {
       gameMode: signal('local'),
       isRoomMode: signal(false),
       openSipGiveModalEvent$: NEVER,
+      lastTurnSips: signal<Record<string, number>>({}),
     }
   );
+  mock.getLastTurnSipsForPlayer.and.returnValue(0);
   mock.isNewGame.and.returnValue(true);
   mock.isGameStarted.and.returnValue(false);
   mock.isGameFinished.and.returnValue(false);


### PR DESCRIPTION
## Summary
- Added `lastTurnSips` signal system to track per-card sip assignments
- Per-turn sip badge (+X, yellow) shown on player card, resets at turn boundaries
- Cleared on new round, phase transition, and game reset
- 9 new tests

## Test plan
- [ ] Phase 1: wrong prediction → sip badge appears → next turn → badge resets
- [ ] Cumulative sip total in header stays correct
- [ ] Phase 2 transition clears badges
- [ ] All 877 tests pass