### PR TITLE
fix: rename guest button, fix Appwrite port and duplicate import

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,7 +6,6 @@ import { environment } from 'src/environments/environment';
 import { PlayerHelperService } from './_shared/_helpers/player.helper';
 import { AuthService } from './services/auth/auth.service';
 import { GameService } from './services/game/game.service';
-import { AuthService } from './services/auth/auth.service';
 import { SoloRoomService } from './services/solo-room/solo-room.service';
 import { HeaderComponent } from './_shared/_components/header/header.component';
 import { FooterComponent } from './_shared/_components/footer/footer.component';
@@ -24,7 +23,6 @@ export class AppComponent implements OnInit {
   readonly gameSrv = inject(GameService);
   readonly translate = inject(TranslateService);
   readonly playerSrv = inject(PlayerHelperService);
-  private readonly authService = inject(AuthService);
   private readonly soloRoomService = inject(SoloRoomService);
 
   readonly withSummaryMode: Signal<boolean>;

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -44,7 +44,7 @@
     "fullName": "Vollständiger Name",
     "forgotPassword": "Passwort vergessen?",
     "continueWithGoogle": "Mit Google fortfahren",
-    "playAsGuest": "Als Gast spielen",
+    "playAsGuest": "Schnelles Spiel",
     "noAccount": "Noch kein Konto?",
     "hasAccount": "Bereits ein Konto?",
     "createAccount": "Konto erstellen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -45,7 +45,7 @@
     "fullName": "Full name",
     "forgotPassword": "Forgot password?",
     "continueWithGoogle": "Continue with Google",
-    "playAsGuest": "Play as guest",
+    "playAsGuest": "Quick play",
     "noAccount": "Don't have an account?",
     "hasAccount": "Already have an account?",
     "createAccount": "Create my account",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -45,7 +45,7 @@
     "fullName": "Nom complet",
     "forgotPassword": "Mot de passe oublié?",
     "continueWithGoogle": "Continuer avec Google",
-    "playAsGuest": "Jouer en tant qu'invité",
+    "playAsGuest": "Partie rapide",
     "noAccount": "Pas encore de compte?",
     "hasAccount": "Déjà un compte?",
     "createAccount": "Créer mon compte",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -44,7 +44,7 @@
     "fullName": "Volledige naam",
     "forgotPassword": "Wachtwoord vergeten?",
     "continueWithGoogle": "Doorgaan met Google",
-    "playAsGuest": "Spelen als gast",
+    "playAsGuest": "Snel spelen",
     "noAccount": "Nog geen account?",
     "hasAccount": "Al een account?",
     "createAccount": "Account aanmaken",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,7 +2,7 @@ export const environment = {
   production: false,
   defaultLanguage: 'fr',
   appwrite: {
-    endpoint: 'http://localhost:8080/v1',
+    endpoint: 'http://localhost:9000/v1',
     projectId: 'fug',
   },
 };


### PR DESCRIPTION
## Summary
- Rename "Jouer en tant qu'invité" → "Partie rapide" (all 4 languages)
- Fix Appwrite endpoint port 8080 → 9000 (matching Docker config)
- Fix duplicate AuthService import in app.component.ts (merge conflict residue)

## Test plan
- [ ] Login page shows "Partie rapide" button
- [ ] App connects to Appwrite on port 9000
- [ ] No compilation errors