### PR TITLE
feat: guest menu with connect and quit options (Story 14.12)

### DIFF
--- a/src/app/_shared/_components/side-menu/side-menu.component.html
+++ b/src/app/_shared/_components/side-menu/side-menu.component.html
@@ -25,13 +25,25 @@
       <div class="side-menu-divider"></div>
     }
 
-    <!-- Auth actions -->
-    @if (isLoggedIn()) {
+    <!-- Auth actions: different options for anonymous vs connected users -->
+    @if (isLoggedIn() && isAnonymous()) {
+      <!-- Anonymous (guest) user: show Connect and Quit -->
+      <button type="button" class="side-menu-item" (click)="connectToAccount()" [disabled]="isLoading()">
+        <fa-icon [icon]="['fas', 'sign-in-alt']" class="side-menu-icon"></fa-icon>
+        <span [translate]="'menu.connect'"></span>
+      </button>
+      <button type="button" class="side-menu-item side-menu-item--danger" (click)="quitGame()" [disabled]="isLoading()">
+        <fa-icon [icon]="['fas', 'door-open']" class="side-menu-icon"></fa-icon>
+        <span [translate]="'menu.quitGame'"></span>
+      </button>
+    } @else if (isLoggedIn()) {
+      <!-- Connected user (email/Google): show Logout -->
       <button type="button" class="side-menu-item side-menu-item--danger" (click)="logout()" [disabled]="isLoading()">
         <fa-icon [icon]="['fas', 'sign-out-alt']" class="side-menu-icon"></fa-icon>
         <span [translate]="'userMenu.logout'"></span>
       </button>
     } @else if (!isAuthPage()) {
+      <!-- Not logged in and not on auth page: show Login -->
       <button type="button" class="side-menu-item" (click)="navigateToLogin()">
         <fa-icon [icon]="['fas', 'sign-in-alt']" class="side-menu-icon"></fa-icon>
         <span [translate]="'userMenu.login'"></span>

--- a/src/app/_shared/_components/side-menu/side-menu.component.spec.ts
+++ b/src/app/_shared/_components/side-menu/side-menu.component.spec.ts
@@ -6,6 +6,7 @@ import { Subject } from 'rxjs';
 import { SideMenuComponent } from './side-menu.component';
 import { GameService } from '../../../services/game/game.service';
 import { AuthService } from '../../../services/auth/auth.service';
+import { AppwriteService } from '../../../services/appwrite/appwrite.service';
 import { createMockGameService, createMockAuthService } from '../../../testing/test-helpers';
 
 describe('SideMenuComponent', () => {
@@ -14,6 +15,7 @@ describe('SideMenuComponent', () => {
   let mockGameService: ReturnType<typeof createMockGameService>;
   let mockAuthService: ReturnType<typeof createMockAuthService>;
   let mockRouter: jasmine.SpyObj<Router>;
+  let mockAppwriteService: { account: { deleteSession: jasmine.Spy } };
   let routerEventsSubject: Subject<Event>;
 
   beforeEach(async () => {
@@ -24,12 +26,18 @@ describe('SideMenuComponent', () => {
       events: routerEventsSubject.asObservable(),
       url: '/',
     });
+    mockAppwriteService = {
+      account: {
+        deleteSession: jasmine.createSpy('deleteSession').and.resolveTo({}),
+      },
+    };
 
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), SideMenuComponent],
       providers: [
         { provide: GameService, useValue: mockGameService },
         { provide: AuthService, useValue: mockAuthService },
+        { provide: AppwriteService, useValue: mockAppwriteService },
         { provide: Router, useValue: mockRouter },
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -122,6 +130,39 @@ describe('SideMenuComponent', () => {
       await component.logout();
       expect(mockAuthService.logout).toHaveBeenCalled();
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+      expect(component.isOpen()).toBeFalse();
+    });
+  });
+
+  describe('guest menu actions', () => {
+    it('should expose isAnonymous from AuthService', () => {
+      expect(component.isAnonymous()).toBeFalse();
+      mockAuthService.isAnonymous.set(true);
+      expect(component.isAnonymous()).toBeTrue();
+    });
+
+    it('should delete anonymous session and navigate to login on connectToAccount', async () => {
+      component.openMenu();
+      await component.connectToAccount();
+      expect(mockAppwriteService.account.deleteSession).toHaveBeenCalledWith('current');
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+      expect(component.isOpen()).toBeFalse();
+      expect(mockAuthService.logout).not.toHaveBeenCalled();
+    });
+
+    it('should navigate to login even if deleteSession fails on connectToAccount', async () => {
+      mockAppwriteService.account.deleteSession.and.rejectWith(new Error('Network error'));
+      component.openMenu();
+      await component.connectToAccount();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+      expect(component.isOpen()).toBeFalse();
+    });
+
+    it('should call full logout and navigate to login on quitGame', async () => {
+      component.openMenu();
+      await component.quitGame();
+      expect(mockAuthService.logout).toHaveBeenCalled();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
       expect(component.isOpen()).toBeFalse();
     });
   });

--- a/src/app/_shared/_components/side-menu/side-menu.component.ts
+++ b/src/app/_shared/_components/side-menu/side-menu.component.ts
@@ -5,6 +5,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { filter, map, startWith } from 'rxjs/operators';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FontAwesomeIconsModule } from '../../../font-awesome.module';
+import { AppwriteService } from '../../../services/appwrite/appwrite.service';
 import { AuthService } from '../../../services/auth/auth.service';
 import { GameService } from '../../../services/game/game.service';
 import { LanguageService } from '../../_helpers/language.helper';
@@ -24,6 +25,7 @@ const AUTH_ROUTES = ['/login', '/register', '/forgot-password'];
 export class SideMenuComponent {
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly appwrite = inject(AppwriteService);
   private readonly authService = inject(AuthService);
   private readonly translate = inject(TranslateService);
   private readonly languageService = inject(LanguageService);
@@ -43,6 +45,9 @@ export class SideMenuComponent {
 
   /** Current user from AuthService */
   readonly isLoggedIn = this.authService.isLoggedIn;
+
+  /** Whether the current session is anonymous (guest) */
+  readonly isAnonymous = this.authService.isAnonymous;
 
   /** Loading state from AuthService */
   readonly isLoading = this.authService.isLoading;
@@ -124,6 +129,24 @@ export class SideMenuComponent {
   navigateToLogin(): void {
     this.closeMenu();
     this.router.navigate(['/login']);
+  }
+
+  /** Navigate to login to connect an account (anonymous users only, preserves game data) */
+  async connectToAccount(): Promise<void> {
+    this.closeMenu();
+    try {
+      await this.appwrite.account.deleteSession('current');
+    } catch {
+      // Session might already be invalid, continue
+    }
+    await this.router.navigate(['/login']);
+  }
+
+  /** Quit the game entirely: full logout with game cleanup (anonymous users only) */
+  async quitGame(): Promise<void> {
+    this.closeMenu();
+    await this.authService.logout();
+    await this.router.navigate(['/login']);
   }
 
   /** Logout the current user */

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,7 +5,6 @@ import { TranslateModule } from '@ngx-translate/core';
 import { AppComponent } from './app.component';
 import { AuthService } from './services/auth/auth.service';
 import { GameService } from './services/game/game.service';
-import { AuthService } from './services/auth/auth.service';
 import { SoloRoomService } from './services/solo-room/solo-room.service';
 import { PlayerHelperService } from './_shared/_helpers/player.helper';
 import { HeaderComponent } from './_shared/_components/header/header.component';
@@ -38,7 +37,6 @@ describe('AppComponent', () => {
     isNewGame: jasmine.Spy;
     handleReconnection: jasmine.Spy;
   };
-  let mockAuthService: { isAnonymous: ReturnType<typeof signal<boolean>> };
   let mockPlayerHelperService: jasmine.SpyObj<PlayerHelperService>;
   let mockAuthService: ReturnType<typeof createMockAuthService>;
   let mockSoloRoomService: ReturnType<typeof createMockSoloRoomService>;
@@ -54,10 +52,6 @@ describe('AppComponent', () => {
       handleReconnection: jasmine.createSpy('handleReconnection').and.resolveTo(undefined),
     };
 
-    mockAuthService = {
-      isAnonymous: signal<boolean>(false),
-    };
-
     mockPlayerHelperService = jasmine.createSpyObj('PlayerHelperService', ['getPlayerNumber']);
     mockPlayerHelperService.getPlayerNumber.and.returnValue(0);
     mockAuthService = createMockAuthService();
@@ -70,7 +64,6 @@ describe('AppComponent', () => {
         { provide: AuthService, useValue: mockAuthService },
         { provide: GameService, useValue: mockGameService },
         { provide: PlayerHelperService, useValue: mockPlayerHelperService },
-        { provide: AuthService, useValue: mockAuthService },
         { provide: SoloRoomService, useValue: mockSoloRoomService },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -68,6 +68,10 @@
       "loggedIn": "Erfolgreich angemeldet"
     }
   },
+  "menu": {
+    "connect": "Anmelden",
+    "quitGame": "Spiel beenden"
+  },
   "userMenu": {
     "login": "Anmelden",
     "logout": "Abmelden",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -127,6 +127,10 @@
       "roomNotFound": "Room not found"
     }
   },
+  "menu": {
+    "connect": "Log in",
+    "quitGame": "Quit game"
+  },
   "userMenu": {
     "login": "Log in",
     "logout": "Log out",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -131,6 +131,10 @@
       "roomNotFound": "Room introuvable"
     }
   },
+  "menu": {
+    "connect": "Se connecter",
+    "quitGame": "Quitter la partie"
+  },
   "userMenu": {
     "login": "Se connecter",
     "logout": "Se déconnecter",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -68,6 +68,10 @@
       "loggedIn": "Succesvol ingelogd"
     }
   },
+  "menu": {
+    "connect": "Inloggen",
+    "quitGame": "Spel verlaten"
+  },
   "userMenu": {
     "login": "Inloggen",
     "logout": "Uitloggen",


### PR DESCRIPTION
## Summary
- Anonymous users see "Se connecter" + "Quitter la partie" in side menu
- "Se connecter" → /login without clearing game (can resume after login)
- "Quitter la partie" → full logout cleanup + /login
- Connected users see "Se déconnecter" (unchanged)
- i18n in 4 languages, 4 new tests
- Fixed duplicate AuthService import in app.component.spec.ts

## Test plan
- [ ] Partie rapide → menu shows "Se connecter" + "Quitter la partie"
- [ ] "Se connecter" → login page, game data preserved
- [ ] "Quitter la partie" → login page, game data cleared
- [ ] Login with account → menu shows "Se déconnecter"
- [ ] All 901 tests pass