### PR TITLE
feat: summary checkbox via canShowSummary for all connected users (Story 14.11)

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,7 @@
 
   <div class="content container d-flex gap-1 justify-content-center my-4 mt-2 mb-2">
     <div class="d-flex flex-column gap-2">
-      @if (gameSrv.isNewGame() && playerSrv.getPlayerNumber() > 1 && isPlayersPage() && !authService.isAnonymous()) {
+      @if (canShowSummary()) {
         <div class="summary-toggle">
           <label class="toggle-switch">
             <input

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -208,41 +208,64 @@ describe('AppComponent', () => {
     });
   });
 
-  describe('Summary toggle visibility', () => {
-    it('should show summary toggle when isPlayersPage returns true', () => {
+  describe('canShowSummary', () => {
+    it('should return true when on players page, logged in, and not anonymous', () => {
       spyOn(component, 'isPlayersPage').and.returnValue(true);
-      mockGameService.isNewGame.and.returnValue(true);
-      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(false);
+
+      expect(component.canShowSummary()).toBeTrue();
+    });
+
+    it('should return false when not on players page', () => {
+      spyOn(component, 'isPlayersPage').and.returnValue(false);
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(false);
+
+      expect(component.canShowSummary()).toBeFalse();
+    });
+
+    it('should return false when not logged in', () => {
+      spyOn(component, 'isPlayersPage').and.returnValue(true);
+      mockAuthService.isLoggedIn.set(false);
+      mockAuthService.isAnonymous.set(false);
+
+      expect(component.canShowSummary()).toBeFalse();
+    });
+
+    it('should return false when user is anonymous', () => {
+      spyOn(component, 'isPlayersPage').and.returnValue(true);
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(true);
+
+      expect(component.canShowSummary()).toBeFalse();
+    });
+
+    it('should return true regardless of player count (0 players)', () => {
+      spyOn(component, 'isPlayersPage').and.returnValue(true);
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(false);
+      mockPlayerHelperService.getPlayerNumber.and.returnValue(0);
+
+      expect(component.canShowSummary()).toBeTrue();
+    });
+  });
+
+  describe('Summary toggle visibility', () => {
+    it('should show summary toggle when canShowSummary returns true', () => {
+      spyOn(component, 'isPlayersPage').and.returnValue(true);
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(false);
       fixture.detectChanges();
 
       const toggle = fixture.nativeElement.querySelector('.summary-toggle');
       expect(toggle).toBeTruthy();
     });
 
-    it('should hide summary toggle when isPlayersPage returns false', () => {
+    it('should hide summary toggle when not on players page', () => {
       spyOn(component, 'isPlayersPage').and.returnValue(false);
-      mockGameService.isNewGame.and.returnValue(true);
-      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
-      fixture.detectChanges();
-
-      const toggle = fixture.nativeElement.querySelector('.summary-toggle');
-      expect(toggle).toBeFalsy();
-    });
-
-    it('should hide summary toggle when game is not new', () => {
-      spyOn(component, 'isPlayersPage').and.returnValue(true);
-      mockGameService.isNewGame.and.returnValue(false);
-      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
-      fixture.detectChanges();
-
-      const toggle = fixture.nativeElement.querySelector('.summary-toggle');
-      expect(toggle).toBeFalsy();
-    });
-
-    it('should hide summary toggle when less than 2 players', () => {
-      spyOn(component, 'isPlayersPage').and.returnValue(true);
-      mockGameService.isNewGame.and.returnValue(true);
-      mockPlayerHelperService.getPlayerNumber.and.returnValue(1);
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(false);
       fixture.detectChanges();
 
       const toggle = fixture.nativeElement.querySelector('.summary-toggle');
@@ -251,8 +274,7 @@ describe('AppComponent', () => {
 
     it('should hide summary toggle when user is anonymous', () => {
       spyOn(component, 'isPlayersPage').and.returnValue(true);
-      mockGameService.isNewGame.and.returnValue(true);
-      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
+      mockAuthService.isLoggedIn.set(true);
       mockAuthService.isAnonymous.set(true);
       fixture.detectChanges();
 
@@ -260,11 +282,11 @@ describe('AppComponent', () => {
       expect(toggle).toBeFalsy();
     });
 
-    it('should show summary toggle when user is not anonymous', () => {
+    it('should show summary toggle with 0 players for connected user', () => {
       spyOn(component, 'isPlayersPage').and.returnValue(true);
-      mockGameService.isNewGame.and.returnValue(true);
-      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
+      mockAuthService.isLoggedIn.set(true);
       mockAuthService.isAnonymous.set(false);
+      mockPlayerHelperService.getPlayerNumber.and.returnValue(0);
       fixture.detectChanges();
 
       const toggle = fixture.nativeElement.querySelector('.summary-toggle');

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,6 +32,17 @@ export class AppComponent implements OnInit {
     return this.router.url.split('?')[0] === '/players';
   }
 
+  /**
+   * Determines if the summary checkbox should be visible.
+   * Visible for connected (non-anonymous) users on the /players page.
+   * Designed to be extended later with subscription checks.
+   */
+  readonly canShowSummary = computed(() => {
+    return this.isPlayersPage()
+      && this.authService.isLoggedIn()
+      && !this.authService.isAnonymous();
+  });
+
   constructor() {
     const defaultLang = this.translate.getBrowserLang() ?? environment.defaultLanguage;
     this.translate.setDefaultLang(defaultLang);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,12 +36,16 @@ export class AppComponent implements OnInit {
    * Determines if the summary checkbox should be visible.
    * Visible for connected (non-anonymous) users on the /players page.
    * Designed to be extended later with subscription checks.
+   *
+   * Note: This is a method (not a computed signal) because isPlayersPage()
+   * depends on router.url which is not a signal. A computed would cache the
+   * result and not re-evaluate on route changes.
    */
-  readonly canShowSummary = computed(() => {
+  canShowSummary(): boolean {
     return this.isPlayersPage()
       && this.authService.isLoggedIn()
       && !this.authService.isAnonymous();
-  });
+  }
 
   constructor() {
     const defaultLang = this.translate.getBrowserLang() ?? environment.defaultLanguage;


### PR DESCRIPTION
## Summary
- New `canShowSummary` computed signal: visible for connected non-anonymous users on /players
- Removed playerCount >= 2 and isNewGame conditions
- Designed for future subscription gating
- Updated tests

## Test plan
- [ ] Connected user on /players → checkbox visible (even with 0 players)
- [ ] Anonymous user → no checkbox
- [ ] All 904 tests pass