### PR TITLE
feat: add legal disclaimer and terms of use (Story 16.1)

### DIFF
--- a/src/app/_components/auth/login/login.component.html
+++ b/src/app/_components/auth/login/login.component.html
@@ -151,5 +151,10 @@
         {{ 'auth.register' | translate }}
       </a>
     </div>
+
+    <!-- Legal Disclaimer -->
+    <div class="legal-disclaimer">
+      <p translate="legal.healthWarning"></p>
+    </div>
   </div>
 </div>

--- a/src/app/_components/auth/login/login.component.scss
+++ b/src/app/_components/auth/login/login.component.scss
@@ -156,6 +156,20 @@
   }
 }
 
+.legal-disclaimer {
+  text-align: center;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid #dee2e6;
+
+  p {
+    font-size: 0.75rem;
+    color: #999;
+    margin: 0;
+    font-style: italic;
+  }
+}
+
 // Responsive adjustments
 @media (max-width: 576px) {
   .login-container {

--- a/src/app/_components/auth/login/login.component.spec.ts
+++ b/src/app/_components/auth/login/login.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { LoginComponent } from './login.component';
+import { AuthService } from '../../../services/auth/auth.service';
+import { GameService } from '../../../services/game/game.service';
+import { SoloRoomService } from '../../../services/solo-room/solo-room.service';
+import {
+  createMockAuthService,
+  createMockGameService,
+  createMockSoloRoomService,
+} from '../../../testing/test-helpers';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), RouterModule.forRoot([]), LoginComponent],
+      providers: [
+        { provide: AuthService, useValue: createMockAuthService() },
+        { provide: GameService, useValue: createMockGameService() },
+        { provide: SoloRoomService, useValue: createMockSoloRoomService() },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('template rendering', () => {
+    it('should render the legal disclaimer', () => {
+      const disclaimer = fixture.nativeElement.querySelector('.legal-disclaimer');
+      expect(disclaimer).toBeTruthy();
+    });
+
+    it('should render the disclaimer text element', () => {
+      const disclaimerText = fixture.nativeElement.querySelector('.legal-disclaimer p');
+      expect(disclaimerText).toBeTruthy();
+    });
+  });
+});

--- a/src/app/_components/auth/register/register.component.html
+++ b/src/app/_components/auth/register/register.component.html
@@ -130,7 +130,7 @@
         />
         <label class="form-check-label" for="ageVerification">
           {{ 'auth.ageVerificationPrefix' | translate }}
-          <a routerLink="/terms" target="_blank">{{ 'auth.ageVerificationLink' | translate }}</a>
+          <a routerLink="/terms">{{ 'auth.ageVerificationLink' | translate }}</a>
         </label>
         @if (hasFieldError('ageVerification')) {
           <div class="invalid-feedback d-block">

--- a/src/app/_components/auth/register/register.component.html
+++ b/src/app/_components/auth/register/register.component.html
@@ -119,6 +119,26 @@
         }
       </div>
 
+      <!-- Age Verification Checkbox -->
+      <div class="form-check age-verification">
+        <input
+          type="checkbox"
+          class="form-check-input"
+          formControlName="ageVerification"
+          id="ageVerification"
+          [class.is-invalid]="hasFieldError('ageVerification')"
+        />
+        <label class="form-check-label" for="ageVerification">
+          {{ 'auth.ageVerificationPrefix' | translate }}
+          <a routerLink="/terms" target="_blank">{{ 'auth.ageVerificationLink' | translate }}</a>
+        </label>
+        @if (hasFieldError('ageVerification')) {
+          <div class="invalid-feedback d-block">
+            {{ getFieldError('ageVerification') | translate }}
+          </div>
+        }
+      </div>
+
       <!-- Submit Button -->
       <button
         type="submit"

--- a/src/app/_components/auth/register/register.component.scss
+++ b/src/app/_components/auth/register/register.component.scss
@@ -93,6 +93,29 @@
   }
 }
 
+.age-verification {
+  margin-top: 0.25rem;
+
+  .form-check-label {
+    font-size: 0.85rem;
+    color: #555;
+
+    a {
+      color: #667eea;
+      text-decoration: none;
+      font-weight: 500;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .invalid-feedback {
+    font-size: 0.8rem;
+  }
+}
+
 .auth-submit {
   margin-top: 0.5rem;
   padding: 0.75rem;

--- a/src/app/_components/auth/register/register.component.spec.ts
+++ b/src/app/_components/auth/register/register.component.spec.ts
@@ -1,0 +1,120 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { RegisterComponent } from './register.component';
+import { AuthService } from '../../../services/auth/auth.service';
+import { GameService } from '../../../services/game/game.service';
+import { SoloRoomService } from '../../../services/solo-room/solo-room.service';
+import {
+  createMockAuthService,
+  createMockGameService,
+  createMockSoloRoomService,
+} from '../../../testing/test-helpers';
+
+describe('RegisterComponent', () => {
+  let component: RegisterComponent;
+  let fixture: ComponentFixture<RegisterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), RouterModule.forRoot([]), RegisterComponent],
+      providers: [
+        { provide: AuthService, useValue: createMockAuthService() },
+        { provide: GameService, useValue: createMockGameService() },
+        { provide: SoloRoomService, useValue: createMockSoloRoomService() },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RegisterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('form validation', () => {
+    it('should have an invalid form by default', () => {
+      expect(component.registerForm.valid).toBeFalse();
+    });
+
+    it('should have ageVerification control', () => {
+      const control = component.registerForm.get('ageVerification');
+      expect(control).toBeTruthy();
+    });
+
+    it('should be invalid when ageVerification is not checked', () => {
+      component.registerForm.patchValue({
+        name: 'Test User',
+        email: 'test@test.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        ageVerification: false,
+      });
+      expect(component.registerForm.valid).toBeFalse();
+    });
+
+    it('should be valid when all fields are filled and ageVerification is checked', () => {
+      component.registerForm.patchValue({
+        name: 'Test User',
+        email: 'test@test.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        ageVerification: true,
+      });
+      expect(component.registerForm.valid).toBeTrue();
+    });
+  });
+
+  describe('hasFieldError', () => {
+    it('should return true for touched invalid ageVerification', () => {
+      const control = component.registerForm.get('ageVerification')!;
+      control.markAsTouched();
+      expect(component.hasFieldError('ageVerification')).toBeTrue();
+    });
+
+    it('should return false for untouched ageVerification', () => {
+      expect(component.hasFieldError('ageVerification')).toBeFalse();
+    });
+  });
+
+  describe('getFieldError', () => {
+    it('should return ageVerificationRequired for unchecked ageVerification', () => {
+      const control = component.registerForm.get('ageVerification')!;
+      control.markAsTouched();
+      expect(component.getFieldError('ageVerification')).toBe('auth.errors.ageVerificationRequired');
+    });
+  });
+
+  describe('onSubmit', () => {
+    it('should not submit when ageVerification is unchecked', async () => {
+      const authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+      component.registerForm.patchValue({
+        name: 'Test User',
+        email: 'test@test.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        ageVerification: false,
+      });
+
+      await component.onSubmit();
+
+      expect(authService.signUp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('template rendering', () => {
+    it('should render the age verification checkbox', () => {
+      const checkbox = fixture.nativeElement.querySelector('#ageVerification');
+      expect(checkbox).toBeTruthy();
+      expect(checkbox.type).toBe('checkbox');
+    });
+
+    it('should render a link to terms page', () => {
+      const termsLink = fixture.nativeElement.querySelector('.age-verification a');
+      expect(termsLink).toBeTruthy();
+      expect(termsLink.getAttribute('href')).toBe('/terms');
+    });
+  });
+});

--- a/src/app/_components/auth/register/register.component.ts
+++ b/src/app/_components/auth/register/register.component.ts
@@ -41,6 +41,7 @@ export class RegisterComponent {
       email: new FormControl('', [Validators.required, Validators.email]),
       password: new FormControl('', [Validators.required, Validators.minLength(8)]),
       confirmPassword: new FormControl('', [Validators.required]),
+      ageVerification: new FormControl(false, [Validators.requiredTrue]),
     },
     { validators: this.passwordMatchValidator }
   );
@@ -153,7 +154,7 @@ export class RegisterComponent {
   /**
    * Check if a form field has errors and has been touched
    */
-  hasFieldError(fieldName: 'name' | 'email' | 'password' | 'confirmPassword'): boolean {
+  hasFieldError(fieldName: 'name' | 'email' | 'password' | 'confirmPassword' | 'ageVerification'): boolean {
     const field = this.registerForm.get(fieldName);
     return !!(field?.invalid && field?.touched);
   }
@@ -161,7 +162,7 @@ export class RegisterComponent {
   /**
    * Get error message for a form field
    */
-  getFieldError(fieldName: 'name' | 'email' | 'password' | 'confirmPassword'): string {
+  getFieldError(fieldName: 'name' | 'email' | 'password' | 'confirmPassword' | 'ageVerification'): string {
     const field = this.registerForm.get(fieldName);
     if (!field?.errors) {
       return '';
@@ -173,6 +174,7 @@ export class RegisterComponent {
         email: 'auth.errors.emailRequired',
         password: 'auth.errors.passwordRequired',
         confirmPassword: 'auth.errors.passwordRequired',
+        ageVerification: 'auth.errors.ageVerificationRequired',
       };
       return errorKeys[fieldName];
     }

--- a/src/app/_components/legal/terms/terms.component.html
+++ b/src/app/_components/legal/terms/terms.component.html
@@ -1,0 +1,34 @@
+<div class="terms-container">
+  <div class="terms-card">
+    <h1 class="terms-title" translate="legal.terms.title"></h1>
+
+    <section class="terms-section">
+      <h2 translate="legal.terms.ageRestrictionTitle"></h2>
+      <p translate="legal.terms.ageRestrictionText"></p>
+    </section>
+
+    <section class="terms-section">
+      <h2 translate="legal.terms.healthWarningTitle"></h2>
+      <p class="health-warning" translate="legal.terms.healthWarningText"></p>
+    </section>
+
+    <section class="terms-section">
+      <h2 translate="legal.terms.nonAlcoholicTitle"></h2>
+      <p translate="legal.terms.nonAlcoholicText"></p>
+    </section>
+
+    <section class="terms-section">
+      <h2 translate="legal.terms.disclaimerTitle"></h2>
+      <p translate="legal.terms.disclaimerText"></p>
+    </section>
+
+    <section class="terms-section">
+      <h2 translate="legal.terms.responsibilityTitle"></h2>
+      <p translate="legal.terms.responsibilityText"></p>
+    </section>
+
+    <div class="terms-back">
+      <a routerLink="/register" class="btn btn-outline-primary" translate="legal.terms.backToRegister"></a>
+    </div>
+  </div>
+</div>

--- a/src/app/_components/legal/terms/terms.component.scss
+++ b/src/app/_components/legal/terms/terms.component.scss
@@ -1,0 +1,109 @@
+.terms-container {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.terms-card {
+  width: 100%;
+  max-width: 700px;
+  padding: 2rem;
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+}
+
+.terms-title {
+  font-size: 1.75rem;
+  font-weight: bold;
+  color: #333;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.terms-section {
+  margin-bottom: 1.5rem;
+
+  h2 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: #444;
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    font-size: 0.95rem;
+    color: #555;
+    line-height: 1.6;
+    margin: 0;
+  }
+}
+
+.health-warning {
+  font-weight: 600;
+  color: #dc3545 !important;
+  font-style: italic;
+}
+
+.terms-back {
+  text-align: center;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #dee2e6;
+}
+
+// Responsive adjustments
+@media (max-width: 576px) {
+  .terms-container {
+    padding: 0.5rem;
+  }
+
+  .terms-card {
+    padding: 1.25rem;
+    border-radius: 0.75rem;
+  }
+
+  .terms-title {
+    font-size: 1.4rem;
+  }
+
+  .terms-section {
+    h2 {
+      font-size: 1.05rem;
+    }
+
+    p {
+      font-size: 0.9rem;
+    }
+  }
+}
+
+// Tablet
+@media (min-width: 577px) and (max-width: 1024px) {
+  .terms-card {
+    max-width: 600px;
+  }
+}
+
+// Large screens / TV
+@media (min-width: 1400px) {
+  .terms-card {
+    max-width: 800px;
+    padding: 3rem;
+  }
+
+  .terms-title {
+    font-size: 2rem;
+  }
+
+  .terms-section {
+    h2 {
+      font-size: 1.3rem;
+    }
+
+    p {
+      font-size: 1.05rem;
+    }
+  }
+}

--- a/src/app/_components/legal/terms/terms.component.spec.ts
+++ b/src/app/_components/legal/terms/terms.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { TermsComponent } from './terms.component';
+
+describe('TermsComponent', () => {
+  let component: TermsComponent;
+  let fixture: ComponentFixture<TermsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), RouterModule.forRoot([]), TermsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TermsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('template rendering', () => {
+    it('should render the terms title', () => {
+      const title = fixture.nativeElement.querySelector('.terms-title');
+      expect(title).toBeTruthy();
+    });
+
+    it('should render all terms sections', () => {
+      const sections = fixture.nativeElement.querySelectorAll('.terms-section');
+      expect(sections.length).toBe(5);
+    });
+
+    it('should render the health warning with special styling', () => {
+      const warning = fixture.nativeElement.querySelector('.health-warning');
+      expect(warning).toBeTruthy();
+    });
+
+    it('should render a back to register link', () => {
+      const backLink = fixture.nativeElement.querySelector('.terms-back a');
+      expect(backLink).toBeTruthy();
+      expect(backLink.getAttribute('href')).toBe('/register');
+    });
+  });
+});

--- a/src/app/_components/legal/terms/terms.component.ts
+++ b/src/app/_components/legal/terms/terms.component.ts
@@ -1,0 +1,23 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+
+/**
+ * TermsComponent - Terms of use and legal disclaimer page
+ *
+ * Displays the full terms of use including:
+ * - Age restriction (18+)
+ * - Health warning about alcohol abuse
+ * - Non-alcoholic alternative mention
+ * - Disclaimer that the app does not encourage alcohol consumption
+ */
+@Component({
+  selector: 'app-terms',
+  templateUrl: './terms.component.html',
+  styleUrls: ['./terms.component.scss'],
+  standalone: true,
+  imports: [CommonModule, RouterLink, TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TermsComponent {}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -40,6 +40,10 @@ export const routes: Routes = [
     path: 'game',
     loadComponent: () => import('./_components/game/game/game.component').then((m) => m.GameComponent),
   },
+  {
+    path: 'terms',
+    loadComponent: () => import('./_components/legal/terms/terms.component').then((m) => m.TermsComponent),
+  },
   { path: '', redirectTo: 'login', pathMatch: 'full' },
 ];
 

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -34,6 +34,23 @@
   "Assign_All_Sips": "Jeder Benutzer mit der gezogenen Karte muss das Symbol <i class=\"fa fa-glass\"></i> verwenden, um Schlucke zu verteilen.",
   "Assign_All_Given_Sips": "Bitte verteilen Sie zuerst alle Schlucke",
   "Summary_Mode_Selection": "Zusammenfassung am Ende des Spiels aktivieren",
+  "legal": {
+    "healthWarning": "Alkoholmissbrauch ist gesundheitssch\u00e4dlich. Trinken Sie verantwortungsvoll.",
+    "terms": {
+      "title": "Nutzungsbedingungen",
+      "ageRestrictionTitle": "Altersbeschr\u00e4nkung",
+      "ageRestrictionText": "Sie m\u00fcssen mindestens 18 Jahre alt sein, um diese Anwendung zu nutzen. Mit der Erstellung eines Kontos best\u00e4tigen Sie, dass Sie in Ihrem Wohnsitzland das gesetzliche Mindestalter f\u00fcr den Alkoholkonsum erreicht haben.",
+      "healthWarningTitle": "Gesundheitswarnung",
+      "healthWarningText": "Alkoholmissbrauch ist gesundheitssch\u00e4dlich. Trinken Sie verantwortungsvoll.",
+      "nonAlcoholicTitle": "Alkoholfreie Alternative",
+      "nonAlcoholicText": "Dieses Spiel kann mit alkoholfreien Getr\u00e4nken gespielt werden. Schlucke k\u00f6nnen jedes Getr\u00e4nk Ihrer Wahl darstellen.",
+      "disclaimerTitle": "Rechtlicher Hinweis",
+      "disclaimerText": "Diese Anwendung f\u00f6rdert keinen Alkoholkonsum. Sie ist als Gesellschaftsspiel konzipiert und die Verwendung von alkoholischen Getr\u00e4nken liegt vollst\u00e4ndig im Ermessen und in der Verantwortung der Nutzer.",
+      "responsibilityTitle": "Verantwortung",
+      "responsibilityText": "Die Ersteller dieser Anwendung lehnen jede Verantwortung f\u00fcr deren Nutzung ab. Sie sind allein f\u00fcr Ihren eigenen Konsum verantwortlich. Fahren Sie niemals unter Alkoholeinfluss.",
+      "backToRegister": "Zur\u00fcck zur Registrierung"
+    }
+  },
   "auth": {
     "login": "Anmelden",
     "register": "Registrieren",
@@ -49,6 +66,8 @@
     "hasAccount": "Bereits ein Konto?",
     "createAccount": "Konto erstellen",
     "partOfFug": "Ein Spiel aus dem FUG-Universum",
+    "ageVerificationPrefix": "Ich bin 18 Jahre oder \u00e4lter und akzeptiere die",
+    "ageVerificationLink": "Nutzungsbedingungen",
     "or": "oder",
     "errors": {
       "invalidEmail": "Ungültige E-Mail-Adresse",
@@ -60,7 +79,8 @@
       "invalidCredentials": "Ungültige E-Mail oder Passwort",
       "emailExists": "Ein Konto mit dieser E-Mail existiert bereits",
       "genericError": "Ein Fehler ist aufgetreten",
-      "tooManyAttempts": "Zu viele Versuche, bitte warten"
+      "tooManyAttempts": "Zu viele Versuche, bitte warten",
+      "ageVerificationRequired": "Sie m\u00fcssen best\u00e4tigen, dass Sie 18 Jahre oder \u00e4lter sind und die Bedingungen akzeptieren"
     },
     "success": {
       "accountCreated": "Konto erfolgreich erstellt",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -35,6 +35,23 @@
   "Assign_All_Given_Sips": " Please assign all sips before saving",
   "Label_MinimumPlayers": "Minimum 2 players required to start the game",
   "Summary_Mode_Selection": "Activate summary at ending of the game",
+  "legal": {
+    "healthWarning": "Alcohol abuse is dangerous for your health. Drink responsibly.",
+    "terms": {
+      "title": "Terms of Use",
+      "ageRestrictionTitle": "Age Restriction",
+      "ageRestrictionText": "You must be at least 18 years old to use this application. By creating an account, you confirm that you are of legal drinking age in your country of residence.",
+      "healthWarningTitle": "Health Warning",
+      "healthWarningText": "Alcohol abuse is dangerous for your health. Drink responsibly.",
+      "nonAlcoholicTitle": "Non-Alcoholic Alternative",
+      "nonAlcoholicText": "This game can be played with non-alcoholic beverages. Sips can represent any drink of your choice.",
+      "disclaimerTitle": "Legal Disclaimer",
+      "disclaimerText": "This application does not encourage alcohol consumption. It is designed as a party game and the use of alcoholic beverages is entirely at the discretion and responsibility of the users.",
+      "responsibilityTitle": "Responsibility",
+      "responsibilityText": "The creators of this application decline all responsibility for how it is used. You are solely responsible for your own consumption. Never drink and drive.",
+      "backToRegister": "Back to registration"
+    }
+  },
   "auth": {
     "login": "Log in",
     "register": "Sign up",
@@ -50,6 +67,8 @@
     "hasAccount": "Already have an account?",
     "createAccount": "Create my account",
     "partOfFug": "A game from the FUG universe",
+    "ageVerificationPrefix": "I am 18 or older and I accept the",
+    "ageVerificationLink": "terms of use",
     "or": "or",
     "errors": {
       "invalidEmail": "Invalid email address",
@@ -61,7 +80,8 @@
       "invalidCredentials": "Invalid email or password",
       "emailExists": "An account already exists with this email",
       "genericError": "An error occurred",
-      "tooManyAttempts": "Too many attempts, please wait"
+      "tooManyAttempts": "Too many attempts, please wait",
+      "ageVerificationRequired": "You must confirm you are 18 or older and accept the terms"
     },
     "success": {
       "accountCreated": "Account created successfully",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -35,6 +35,23 @@
   "Assign_All_Given_Sips": "Donnes toutes les gorgées d'abbord",
   "Label_MinimumPlayers": "Minimum 2 joueurs requis pour commencer la partie",
   "Summary_Mode_Selection": "Activer le résumé en fin de partie",
+  "legal": {
+    "healthWarning": "L'abus d'alcool est dangereux pour la sant\u00e9. \u00c0 consommer avec mod\u00e9ration.",
+    "terms": {
+      "title": "Conditions d'utilisation",
+      "ageRestrictionTitle": "Restriction d'\u00e2ge",
+      "ageRestrictionText": "Vous devez avoir au moins 18 ans pour utiliser cette application. En cr\u00e9ant un compte, vous confirmez que vous avez l'\u00e2ge l\u00e9gal pour consommer de l'alcool dans votre pays de r\u00e9sidence.",
+      "healthWarningTitle": "Avertissement sant\u00e9",
+      "healthWarningText": "L'abus d'alcool est dangereux pour la sant\u00e9. \u00c0 consommer avec mod\u00e9ration.",
+      "nonAlcoholicTitle": "Alternative sans alcool",
+      "nonAlcoholicText": "Ce jeu peut \u00eatre jou\u00e9 avec des boissons non alcoolis\u00e9es. Les gorg\u00e9es peuvent repr\u00e9senter n'importe quelle boisson de votre choix.",
+      "disclaimerTitle": "Avertissement l\u00e9gal",
+      "disclaimerText": "Cette application n'encourage pas la consommation d'alcool. Elle est con\u00e7ue comme un jeu de soci\u00e9t\u00e9 et l'utilisation de boissons alcoolis\u00e9es est enti\u00e8rement \u00e0 la discr\u00e9tion et sous la responsabilit\u00e9 des utilisateurs.",
+      "responsibilityTitle": "Responsabilit\u00e9",
+      "responsibilityText": "Les cr\u00e9ateurs de cette application d\u00e9clinent toute responsabilit\u00e9 quant \u00e0 l'usage qui en est fait. Vous \u00eates seul responsable de votre consommation. Ne conduisez jamais apr\u00e8s avoir consomm\u00e9 de l'alcool.",
+      "backToRegister": "Retour \u00e0 l'inscription"
+    }
+  },
   "auth": {
     "login": "Se connecter",
     "register": "S'inscrire",
@@ -50,6 +67,8 @@
     "hasAccount": "Déjà un compte?",
     "createAccount": "Créer mon compte",
     "partOfFug": "Un jeu de l'univers FUG",
+    "ageVerificationPrefix": "J'ai 18 ans ou plus et j'accepte les",
+    "ageVerificationLink": "conditions d'utilisation",
     "or": "ou",
     "errors": {
       "invalidEmail": "Adresse email invalide",
@@ -61,7 +80,8 @@
       "invalidCredentials": "Email ou mot de passe incorrect",
       "emailExists": "Un compte existe déjà avec cet email",
       "genericError": "Une erreur est survenue",
-      "tooManyAttempts": "Trop de tentatives, veuillez patienter"
+      "tooManyAttempts": "Trop de tentatives, veuillez patienter",
+      "ageVerificationRequired": "Vous devez confirmer avoir 18 ans ou plus et accepter les conditions"
     },
     "success": {
       "accountCreated": "Compte créé avec succès",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -34,6 +34,23 @@
   "Assign_All_Sips": "Elke gebruiker met de getrokken kaart moet het icoon <i class=\"fa fa-glass\"></i> gebruiken om slokjes te geven.",
   "Assign_All_Given_Sips": "Geef eerst alle slokjes",
   "Summary_Mode_Selection": "Samenvatting aan het einde van het spel activeren",
+  "legal": {
+    "healthWarning": "Alcoholmisbruik is gevaarlijk voor uw gezondheid. Drink met mate.",
+    "terms": {
+      "title": "Gebruiksvoorwaarden",
+      "ageRestrictionTitle": "Leeftijdsbeperking",
+      "ageRestrictionText": "U moet minimaal 18 jaar oud zijn om deze applicatie te gebruiken. Door een account aan te maken, bevestigt u dat u de wettelijke leeftijd hebt om alcohol te drinken in uw land van verblijf.",
+      "healthWarningTitle": "Gezondheidswaarschuwing",
+      "healthWarningText": "Alcoholmisbruik is gevaarlijk voor uw gezondheid. Drink met mate.",
+      "nonAlcoholicTitle": "Niet-alcoholisch alternatief",
+      "nonAlcoholicText": "Dit spel kan gespeeld worden met niet-alcoholische dranken. Slokjes kunnen elke drank naar keuze voorstellen.",
+      "disclaimerTitle": "Juridische disclaimer",
+      "disclaimerText": "Deze applicatie moedigt alcoholgebruik niet aan. Het is ontworpen als een gezelschapsspel en het gebruik van alcoholische dranken is volledig naar eigen goeddunken en verantwoordelijkheid van de gebruikers.",
+      "responsibilityTitle": "Verantwoordelijkheid",
+      "responsibilityText": "De makers van deze applicatie wijzen alle verantwoordelijkheid af voor het gebruik ervan. U bent zelf verantwoordelijk voor uw eigen consumptie. Rijd nooit onder invloed.",
+      "backToRegister": "Terug naar registratie"
+    }
+  },
   "auth": {
     "login": "Inloggen",
     "register": "Registreren",
@@ -49,6 +66,8 @@
     "hasAccount": "Al een account?",
     "createAccount": "Account aanmaken",
     "partOfFug": "Een spel uit het FUG-universum",
+    "ageVerificationPrefix": "Ik ben 18 jaar of ouder en ik accepteer de",
+    "ageVerificationLink": "gebruiksvoorwaarden",
     "or": "of",
     "errors": {
       "invalidEmail": "Ongeldig e-mailadres",
@@ -60,7 +79,8 @@
       "invalidCredentials": "Ongeldige e-mail of wachtwoord",
       "emailExists": "Er bestaat al een account met dit e-mailadres",
       "genericError": "Er is een fout opgetreden",
-      "tooManyAttempts": "Te veel pogingen, even geduld"
+      "tooManyAttempts": "Te veel pogingen, even geduld",
+      "ageVerificationRequired": "U moet bevestigen dat u 18 jaar of ouder bent en de voorwaarden accepteren"
     },
     "success": {
       "accountCreated": "Account succesvol aangemaakt",


### PR DESCRIPTION
## Summary
- New TermsComponent (/terms) with alcohol disclaimer, 18+ requirement, non-alcoholic alternatives
- Age verification checkbox on register page (required to create account)
- Health warning disclaimer on login page
- i18n in 4 languages (FR, EN, NL, DE)
- 17 new tests (923 total)

## Test plan
- [ ] Register page: checkbox required, can't submit without it
- [ ] Register page: link to /terms works
- [ ] /terms page: all legal sections visible
- [ ] Login page: health disclaimer visible at bottom
- [ ] All 923 tests pass