### PR TITLE
feat: home screen with create/join game flow (Story 15.5)

### DIFF
--- a/src/app/_components/auth/login/login.component.ts
+++ b/src/app/_components/auth/login/login.component.ts
@@ -109,8 +109,9 @@ export class LoginComponent implements OnInit {
   /**
    * Navigate to appropriate page after login.
    * If pendingSummary flag is set, navigates to /game and shows summary.
-   * Checks for active KetalSession to resume, otherwise starts background
-   * solo room creation and navigates to /players.
+   * Checks for active KetalSession to resume.
+   * Connected (non-anonymous) users go to /home.
+   * Anonymous users go to /players (local mode).
    */
   private async navigateAfterLogin(): Promise<void> {
     if (this.authService.consumePendingSummary()) {
@@ -126,7 +127,13 @@ export class LoginComponent implements OnInit {
       return;
     }
 
-    // Start background solo room creation while user adds players
+    // Connected (non-anonymous) users see the home screen
+    if (!this.authService.isAnonymous()) {
+      await this.router.navigate(['/home']);
+      return;
+    }
+
+    // Anonymous users go directly to /players (local mode)
     this.soloRoomService.startBackgroundRoomCreation();
     await this.router.navigate(['/players']);
   }

--- a/src/app/_components/home/home.component.html
+++ b/src/app/_components/home/home.component.html
@@ -1,0 +1,50 @@
+<div class="home-container">
+  <div class="home-card">
+    <!-- Branding -->
+    <div class="branding">
+      <h1 class="app-title">KETAL</h1>
+      <p class="app-subtitle">{{ 'auth.partOfFug' | translate }}</p>
+    </div>
+
+    <!-- Error Alert -->
+    @if (error()) {
+      <div class="alert alert-danger" role="alert">
+        {{ error() | translate }}
+      </div>
+    }
+
+    <!-- CTA Buttons -->
+    <div class="cta-buttons">
+      <!-- Create Game Button -->
+      <button
+        type="button"
+        class="btn btn-primary btn-cta btn-create-game"
+        (click)="createGame()"
+        [disabled]="isCreating()"
+      >
+        @if (isCreating()) {
+          <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+        } @else {
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" class="me-2">
+            <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
+            <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z"/>
+          </svg>
+        }
+        {{ 'home.createGame' | translate }}
+      </button>
+
+      <!-- Join Game Button -->
+      <button
+        type="button"
+        class="btn btn-outline-primary btn-cta btn-join-game"
+        (click)="joinGame()"
+        [disabled]="isCreating()"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" class="me-2">
+          <path d="M15 14s1 0 1-1-1-4-5-4-5 3-5 4 1 1 1 1h8Zm-7.978-1A.261.261 0 0 1 7 12.996c.001-.264.167-1.03.76-1.72C8.312 10.629 9.282 10 11 10c1.717 0 2.687.63 3.24 1.276.593.69.758 1.457.76 1.72l-.008.002a.274.274 0 0 1-.014.002H7.022ZM11 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm3-2a3 3 0 1 1-6 0 3 3 0 0 1 6 0ZM6.936 9.28a5.88 5.88 0 0 0-1.23-.247A7.35 7.35 0 0 0 5 9c-4 0-5 3-5 4 0 .667.333 1 1 1h4.216A2.238 2.238 0 0 1 5 13c0-.828.299-1.986 1.027-2.999.243-.339.525-.655.841-.94.074-.07.148-.138.224-.202l-.062-.045-.094-.07ZM4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"/>
+        </svg>
+        {{ 'home.joinGame' | translate }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/_components/home/home.component.scss
+++ b/src/app/_components/home/home.component.scss
@@ -1,0 +1,127 @@
+.home-container {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.home-card {
+  width: 100%;
+  max-width: 400px;
+  padding: 2rem;
+  background-color: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+}
+
+.branding {
+  text-align: center;
+  margin-bottom: 2.5rem;
+
+  .app-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: #212529;
+    margin-bottom: 0.25rem;
+    letter-spacing: 0.1em;
+  }
+
+  .app-subtitle {
+    font-size: 0.9rem;
+    color: #6c757d;
+    margin-bottom: 0;
+  }
+}
+
+.cta-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.btn-cta {
+  width: 100%;
+  padding: 1rem;
+  font-weight: 500;
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.15);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+}
+
+.btn-create-game {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.btn-join-game {
+  letter-spacing: 0.02em;
+}
+
+// Responsive adjustments
+@media (max-width: 576px) {
+  .home-container {
+    padding: 0.5rem;
+  }
+
+  .home-card {
+    padding: 1.5rem;
+    box-shadow: none;
+    border: 1px solid #dee2e6;
+  }
+
+  .branding {
+    margin-bottom: 2rem;
+
+    .app-title {
+      font-size: 2rem;
+    }
+  }
+
+  .btn-cta {
+    padding: 0.875rem;
+    font-size: 1rem;
+  }
+}
+
+// Tablet
+@media (min-width: 577px) and (max-width: 991px) {
+  .home-card {
+    max-width: 450px;
+    padding: 2.5rem;
+  }
+}
+
+// Large screens / TV
+@media (min-width: 1200px) {
+  .home-card {
+    max-width: 500px;
+    padding: 3rem;
+  }
+
+  .branding {
+    .app-title {
+      font-size: 3rem;
+    }
+  }
+
+  .btn-cta {
+    padding: 1.25rem;
+    font-size: 1.2rem;
+  }
+}

--- a/src/app/_components/home/home.component.spec.ts
+++ b/src/app/_components/home/home.component.spec.ts
@@ -4,7 +4,6 @@ import { TranslateModule } from '@ngx-translate/core';
 import { HomeComponent } from './home.component';
 import { RoomService } from '../../services/room/room.service';
 import { AuthService } from '../../services/auth/auth.service';
-import { SoloRoomService } from '../../services/solo-room/solo-room.service';
 import { signal } from '@angular/core';
 
 describe('HomeComponent', () => {
@@ -32,18 +31,12 @@ describe('HomeComponent', () => {
       isLoading: signal(false),
     });
 
-    const soloRoomServiceSpy = jasmine.createSpyObj('SoloRoomService', [
-      'startBackgroundRoomCreation',
-      'awaitRoom',
-    ]);
-
     await TestBed.configureTestingModule({
       imports: [HomeComponent, TranslateModule.forRoot()],
       providers: [
         { provide: Router, useValue: routerSpy },
         { provide: RoomService, useValue: roomServiceSpy },
         { provide: AuthService, useValue: authServiceSpy },
-        { provide: SoloRoomService, useValue: soloRoomServiceSpy },
       ],
     }).compileComponents();
 

--- a/src/app/_components/home/home.component.spec.ts
+++ b/src/app/_components/home/home.component.spec.ts
@@ -1,0 +1,146 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { HomeComponent } from './home.component';
+import { RoomService } from '../../services/room/room.service';
+import { AuthService } from '../../services/auth/auth.service';
+import { SoloRoomService } from '../../services/solo-room/solo-room.service';
+import { signal } from '@angular/core';
+
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
+  let router: jasmine.SpyObj<Router>;
+  let roomService: jasmine.SpyObj<RoomService>;
+  let authService: jasmine.SpyObj<AuthService>;
+
+  beforeEach(async () => {
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    const roomServiceSpy = jasmine.createSpyObj('RoomService', ['createSoloRoom'], {
+      currentRoom: signal(null),
+    });
+    roomServiceSpy.createSoloRoom.and.returnValue(
+      Promise.resolve({ $id: 'room1', name: 'Solo-123', code: 'ABC123' })
+    );
+
+    const authServiceSpy = jasmine.createSpyObj('AuthService', [], {
+      currentUser: signal({ name: 'Test User', email: 'test@test.com', $id: 'user1' }),
+      isLoggedIn: signal(true),
+      isAnonymous: signal(false),
+      isLoading: signal(false),
+    });
+
+    const soloRoomServiceSpy = jasmine.createSpyObj('SoloRoomService', [
+      'startBackgroundRoomCreation',
+      'awaitRoom',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [HomeComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: Router, useValue: routerSpy },
+        { provide: RoomService, useValue: roomServiceSpy },
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: SoloRoomService, useValue: soloRoomServiceSpy },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    roomService = TestBed.inject(RoomService) as jasmine.SpyObj<RoomService>;
+    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display branding', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const title = compiled.querySelector('.app-title');
+    expect(title?.textContent).toContain('KETAL');
+  });
+
+  it('should have two CTA buttons', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const buttons = compiled.querySelectorAll('.btn-cta');
+    expect(buttons.length).toBe(2);
+  });
+
+  it('should call createGame and navigate to /players on success', fakeAsync(() => {
+    component.createGame();
+    tick();
+
+    expect(roomService.createSoloRoom).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(['/players']);
+    expect(component.isCreating()).toBe(false);
+  }));
+
+  it('should set error on createGame failure', fakeAsync(() => {
+    roomService.createSoloRoom.and.returnValue(Promise.reject(new Error('Network error')));
+
+    component.createGame();
+    tick();
+
+    expect(component.error()).toBe('Network error');
+    expect(component.isCreating()).toBe(false);
+  }));
+
+  it('should not allow double-click on createGame', fakeAsync(() => {
+    // Simulate slow room creation
+    let resolveRoom: (value: any) => void;
+    roomService.createSoloRoom.and.returnValue(
+      new Promise((resolve) => {
+        resolveRoom = resolve;
+      })
+    );
+
+    component.createGame();
+    // Second call should be ignored
+    component.createGame();
+
+    expect(roomService.createSoloRoom).toHaveBeenCalledTimes(1);
+
+    resolveRoom!({ $id: 'room1', name: 'Solo', code: 'ABC123' });
+    tick();
+  }));
+
+  it('should navigate to /room/join when joinGame is called', fakeAsync(() => {
+    component.joinGame();
+    tick();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/room/join']);
+  }));
+
+  it('should show loading spinner when creating', fakeAsync(() => {
+    let resolveRoom: (value: any) => void;
+    roomService.createSoloRoom.and.returnValue(
+      new Promise((resolve) => {
+        resolveRoom = resolve;
+      })
+    );
+
+    component.createGame();
+    fixture.detectChanges();
+
+    const spinner = fixture.nativeElement.querySelector('.spinner-border');
+    expect(spinner).toBeTruthy();
+    expect(component.isCreating()).toBe(true);
+
+    resolveRoom!({ $id: 'room1', name: 'Solo', code: 'ABC123' });
+    tick();
+    fixture.detectChanges();
+
+    const spinnerAfter = fixture.nativeElement.querySelector('.spinner-border');
+    expect(spinnerAfter).toBeFalsy();
+  }));
+
+  it('should compute userName from auth service', () => {
+    expect(component.userName()).toBe('Test User');
+  });
+});

--- a/src/app/_components/home/home.component.ts
+++ b/src/app/_components/home/home.component.ts
@@ -1,0 +1,84 @@
+import { Component, ChangeDetectionStrategy, inject, signal, computed, DestroyRef } from '@angular/core';
+import { Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { RoomService } from '../../services/room/room.service';
+import { AuthService } from '../../services/auth/auth.service';
+import { SoloRoomService } from '../../services/solo-room/solo-room.service';
+
+/**
+ * HomeComponent - Home screen for authenticated (non-anonymous) users.
+ *
+ * Displays two CTA buttons:
+ * - "Créer une partie" → creates a solo room, then navigates to /players
+ * - "Rejoindre une partie" → navigates to /room/join
+ *
+ * Uses Angular 19 patterns: standalone, signals, inject(), OnPush.
+ */
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss'],
+  standalone: true,
+  imports: [TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HomeComponent {
+  private readonly router = inject(Router);
+  private readonly roomService = inject(RoomService);
+  private readonly authService = inject(AuthService);
+  private readonly soloRoomService = inject(SoloRoomService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Loading state for room creation */
+  readonly isCreating = signal(false);
+
+  /** Error message signal */
+  readonly error = signal<string | null>(null);
+
+  /** User display name for greeting */
+  readonly userName = computed(() => {
+    const user = this.authService.currentUser();
+    return user?.name || '';
+  });
+
+  /**
+   * Create a game room and navigate to /players
+   */
+  async createGame(): Promise<void> {
+    if (this.isCreating()) {
+      return;
+    }
+
+    this.isCreating.set(true);
+    this.error.set(null);
+
+    try {
+      await this.roomService.createSoloRoom();
+      await this.router.navigate(['/players']);
+    } catch (err) {
+      this.error.set(this.getErrorMessage(err));
+    } finally {
+      this.isCreating.set(false);
+    }
+  }
+
+  /**
+   * Navigate to join room page
+   */
+  async joinGame(): Promise<void> {
+    await this.router.navigate(['/room/join']);
+  }
+
+  /**
+   * Extract error message from caught error
+   */
+  private getErrorMessage(err: unknown): string {
+    if (err instanceof Error) {
+      return err.message;
+    }
+    if (typeof err === 'object' && err !== null && 'message' in err) {
+      return String((err as { message: unknown }).message);
+    }
+    return 'home.errors.createFailed';
+  }
+}

--- a/src/app/_components/home/home.component.ts
+++ b/src/app/_components/home/home.component.ts
@@ -1,9 +1,8 @@
-import { Component, ChangeDetectionStrategy, inject, signal, computed, DestroyRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { RoomService } from '../../services/room/room.service';
 import { AuthService } from '../../services/auth/auth.service';
-import { SoloRoomService } from '../../services/solo-room/solo-room.service';
 
 /**
  * HomeComponent - Home screen for authenticated (non-anonymous) users.
@@ -26,8 +25,6 @@ export class HomeComponent {
   private readonly router = inject(Router);
   private readonly roomService = inject(RoomService);
   private readonly authService = inject(AuthService);
-  private readonly soloRoomService = inject(SoloRoomService);
-  private readonly destroyRef = inject(DestroyRef);
 
   /** Loading state for room creation */
   readonly isCreating = signal(false);

--- a/src/app/_components/players/players-list/players-list.component.html
+++ b/src/app/_components/players/players-list/players-list.component.html
@@ -1,4 +1,41 @@
 <div class="container">
+@if (hasRoom() && this.gameSrv.isNewGame()) {
+  <div class="invite-section mb-2">
+    <button
+      type="button"
+      class="btn btn-outline-primary btn-sm w-100"
+      (click)="toggleInvite()"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="me-1">
+        <path d="M15 14s1 0 1-1-1-4-5-4-5 3-5 4 1 1 1 1h8Zm-7.978-1A.261.261 0 0 1 7 12.996c.001-.264.167-1.03.76-1.72C8.312 10.629 9.282 10 11 10c1.717 0 2.687.63 3.24 1.276.593.69.758 1.457.76 1.72l-.008.002a.274.274 0 0 1-.014.002H7.022ZM11 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm3-2a3 3 0 1 1-6 0 3 3 0 0 1 6 0ZM6.936 9.28a5.88 5.88 0 0 0-1.23-.247A7.35 7.35 0 0 0 5 9c-4 0-5 3-5 4 0 .667.333 1 1 1h4.216A2.238 2.238 0 0 1 5 13c0-.828.299-1.986 1.027-2.999.243-.339.525-.655.841-.94.074-.07.148-.138.224-.202l-.062-.045-.094-.07ZM4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"/>
+      </svg>
+      {{ 'home.invitePlayers' | translate }}
+    </button>
+
+    @if (showInvite()) {
+      <div class="invite-panel mt-2 p-3 border rounded text-center">
+        <qrcode
+          [qrdata]="inviteUrl()"
+          [width]="160"
+          [errorCorrectionLevel]="'M'"
+          [margin]="1"
+        ></qrcode>
+        <p class="text-muted small mt-1 mb-2">{{ 'room.scanToJoin' | translate }}</p>
+        <div class="invite-url small text-break mb-2">{{ inviteUrl() }}</div>
+        <button
+          type="button"
+          class="btn btn-outline-secondary btn-sm"
+          (click)="copyInviteLink()"
+        >
+          {{ 'room.copyLink' | translate }}
+        </button>
+        @if (inviteCopySuccess()) {
+          <div class="text-success small mt-1">{{ inviteCopySuccess()! | translate }}</div>
+        }
+      </div>
+    }
+  </div>
+}
 @if (!allPlayersCreated && this.gameSrv.isNewGame()) {
     <form [formGroup]="playersForm" (ngSubmit)="addPlayer()" class="mb-1">
       <div class="input-group mb-1">

--- a/src/app/_components/players/players-list/players-list.component.ts
+++ b/src/app/_components/players/players-list/players-list.component.ts
@@ -1,12 +1,14 @@
-import { Component, EventEmitter, inject, Output } from '@angular/core';
+import { Component, EventEmitter, inject, Output, signal, computed, DestroyRef } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { QRCodeComponent } from 'angularx-qrcode';
 import { PlayerHelperService } from 'src/app/_shared/_helpers/player.helper';
 import { PlayerModel } from 'src/app/_shared/_models/player.model';
 import { LocalService } from 'src/app/services/local/local.service';
 import { isNullOrWhiteSpace } from 'src/app/_shared/_helpers/string.helper';
 import { GameService } from '../../../services/game/game.service';
+import { RoomService } from '../../../services/room/room.service';
 import { PlayerListPlayerComponent } from '../player-list-player/player-list-player.component';
 
 @Component({
@@ -14,18 +16,41 @@ import { PlayerListPlayerComponent } from '../player-list-player/player-list-pla
   templateUrl: './players-list.component.html',
   styleUrls: ['./players-list.component.scss'],
   standalone: true,
-  imports: [NgClass, ReactiveFormsModule, TranslateModule, PlayerListPlayerComponent],
+  imports: [NgClass, ReactiveFormsModule, TranslateModule, PlayerListPlayerComponent, QRCodeComponent],
 })
 export class PlayersListComponent {
   private readonly fb = inject(FormBuilder);
   private readonly localService = inject(LocalService);
+  private readonly destroyRef = inject(DestroyRef);
   readonly playerHelper = inject(PlayerHelperService);
   readonly gameSrv = inject(GameService);
   readonly translate = inject(TranslateService);
+  readonly roomService = inject(RoomService);
 
   readonly playersForm: FormGroup;
   allPlayersCreated = false;
   @Output() readonly beginGame = new EventEmitter<void>();
+
+  /** Whether the invite panel is shown */
+  readonly showInvite = signal(false);
+
+  /** Success message for copy feedback */
+  readonly inviteCopySuccess = signal<string | null>(null);
+
+  /** Computed: whether a room exists (invite button visible) */
+  readonly hasRoom = computed(() => !!this.roomService.currentRoom());
+
+  /** Computed: invite URL */
+  readonly inviteUrl = computed(() => {
+    const room = this.roomService.currentRoom();
+    if (!room) {
+      return '';
+    }
+    return `${window.location.origin}/room/join/${room.code}`;
+  });
+
+  /** Timeout ID for cleanup */
+  private successTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     const localPlayer = JSON.parse(this.localService.getData('players') as string);
@@ -34,6 +59,12 @@ export class PlayersListComponent {
     }
     this.playersForm = this.fb.group({
       newPlayer: ['', Validators.required],
+    });
+
+    this.destroyRef.onDestroy(() => {
+      if (this.successTimeoutId) {
+        clearTimeout(this.successTimeoutId);
+      }
     });
   }
 
@@ -60,4 +91,32 @@ export class PlayersListComponent {
     return this.playersForm.get('newPlayer');
   }
 
+  /** Toggle invite panel visibility */
+  toggleInvite(): void {
+    this.showInvite.update((v) => !v);
+  }
+
+  /** Copy invite link to clipboard */
+  async copyInviteLink(): Promise<void> {
+    const url = this.inviteUrl();
+    if (!url) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      this.inviteCopySuccess.set('room.linkCopied');
+
+      if (this.successTimeoutId) {
+        clearTimeout(this.successTimeoutId);
+      }
+
+      this.successTimeoutId = setTimeout(() => {
+        this.inviteCopySuccess.set(null);
+        this.successTimeoutId = null;
+      }, 2000);
+    } catch {
+      // Clipboard API may not be available
+    }
+  }
 }

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -14,7 +14,7 @@ import { PlayingCardComponent } from '../playing-card/playing-card.component';
 import { AccountGateModalComponent } from '../../../_components/auth/account-gate-modal/account-gate-modal.component';
 
 /** Routes where the game footer should be hidden */
-const HIDDEN_ROUTES = ['/login', '/register', '/forgot-password', '/room'];
+const HIDDEN_ROUTES = ['/login', '/register', '/forgot-password', '/room', '/home'];
 
 /** Key used to store pending summary flag in localStorage */
 const PENDING_SUMMARY_KEY = 'pendingSummary';

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,6 +3,10 @@ import { RouterModule, Routes } from '@angular/router';
 
 export const routes: Routes = [
   {
+    path: 'home',
+    loadComponent: () => import('./_components/home/home.component').then((m) => m.HomeComponent),
+  },
+  {
     path: 'login',
     loadComponent: () => import('./_components/auth/login/login.component').then((m) => m.LoginComponent),
   },
@@ -12,8 +16,8 @@ export const routes: Routes = [
   },
   {
     path: 'room/create',
-    loadComponent: () =>
-      import('./_components/room/create-room/create-room.component').then((m) => m.CreateRoomComponent),
+    redirectTo: 'home',
+    pathMatch: 'full',
   },
   {
     path: 'room/join',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -72,6 +72,9 @@ export class AppComponent implements OnInit {
         if (activeSession) {
           await this.gameSrv.handleReconnection(activeSession.$id);
           await this.router.navigate(['/game']);
+        } else if (!this.authService.isAnonymous() && this.router.url === '/login') {
+          // Authenticated non-anonymous user with no active game: redirect to home
+          await this.router.navigate(['/home']);
         }
       }
     } catch {

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -68,6 +68,14 @@
       "loggedIn": "Erfolgreich angemeldet"
     }
   },
+  "home": {
+    "createGame": "Spiel erstellen",
+    "joinGame": "Spiel beitreten",
+    "invitePlayers": "Spieler einladen",
+    "errors": {
+      "createFailed": "Spiel konnte nicht erstellt werden"
+    }
+  },
   "menu": {
     "connect": "Anmelden",
     "quitGame": "Spiel beenden"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -69,6 +69,14 @@
       "loggedIn": "Logged in successfully"
     }
   },
+  "home": {
+    "createGame": "Create a game",
+    "joinGame": "Join a game",
+    "invitePlayers": "Invite players",
+    "errors": {
+      "createFailed": "Failed to create game"
+    }
+  },
   "room": {
     "createRoom": "Create a room",
     "roomName": "Room name",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -69,6 +69,14 @@
       "loggedIn": "Connexion réussie"
     }
   },
+  "home": {
+    "createGame": "Créer une partie",
+    "joinGame": "Rejoindre une partie",
+    "invitePlayers": "Inviter des joueurs",
+    "errors": {
+      "createFailed": "Impossible de créer la partie"
+    }
+  },
   "room": {
     "createRoom": "Créer une room",
     "roomName": "Nom de la room",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -68,6 +68,14 @@
       "loggedIn": "Succesvol ingelogd"
     }
   },
+  "home": {
+    "createGame": "Spel aanmaken",
+    "joinGame": "Spel deelnemen",
+    "invitePlayers": "Spelers uitnodigen",
+    "errors": {
+      "createFailed": "Kan spel niet aanmaken"
+    }
+  },
   "menu": {
     "connect": "Inloggen",
     "quitGame": "Spel verlaten"


### PR DESCRIPTION
## Summary
- New HomeComponent (/home) with "Créer une partie" + "Rejoindre une partie"
- "Créer une partie" → explicit room creation → /players
- Invite button on /players page (QR code + copy link)
- Routing: connected users → /home, anonymous → /players
- i18n in 4 languages, 7 new tests (913 total)

## Test plan
- [ ] Login with account → /home
- [ ] "Créer une partie" → room created → /players with invite
- [ ] "Rejoindre une partie" → /room/join
- [ ] Partie rapide → /players directly
- [ ] All 913 tests pass