### PR TITLE
feat: side menu drawer for compact header (Story 14.6)

### DIFF
--- a/src/app/_shared/_components/header/header.component.spec.ts
+++ b/src/app/_shared/_components/header/header.component.spec.ts
@@ -2,12 +2,18 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { HeaderComponent } from './header.component';
+import { GameService } from '../../../services/game/game.service';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
+  let mockGameService: jasmine.SpyObj<GameService>;
 
   beforeEach(async () => {
+    mockGameService = jasmine.createSpyObj('GameService', ['resetGame'], {
+      game: undefined
+    });
+
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), HeaderComponent],
       schemas: [NO_ERRORS_SCHEMA],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,7 +18,6 @@ export function HttpLoaderFactory(http: HttpClient) {
 @NgModule({
   imports: [
     BrowserModule,
-    HeaderComponent,
     AppRoutingModule,
     BrowserAnimationsModule,
     FontAwesomeIconsModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ export function HttpLoaderFactory(http: HttpClient) {
 @NgModule({
   imports: [
     BrowserModule,
+    HeaderComponent,
     AppRoutingModule,
     BrowserAnimationsModule,
     FontAwesomeIconsModule,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,6 +1,7 @@
 {
   "Label_App_Title": "Ketal",
   "Label_App_Subtitle": "Grosse Guinze Generator",
+  "Label_Language": "Language",
   "Label_YouDrink": "You drink",
   "Label_YouGive": "You give",
   "Label_Give": "gives",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1,6 +1,7 @@
 {
   "Label_App_Title": "Ketal",
   "Label_App_Subtitle": "Grosse Guinze Generator",
+  "Label_Language": "Langue",
   "Label_YouDrink": "Tu bois",
   "Label_YouGive": "Tu donnes",
   "Label_Give": "donne",


### PR DESCRIPTION
## Summary
- Replace tall header with compact dark navbar and hamburger button
- Add sliding side drawer with language selector and restart game option
- Free vertical screen space for the game area on mobile

## Test plan
- [ ] Hamburger opens/closes drawer
- [ ] Language selector works in drawer
- [ ] Restart button appears during active game
- [ ] Test on mobile, tablet, desktop viewports