### PR TITLE
fix: Phase 2 card stacking and Appwrite sync (Story 12.13)

### DIFF
--- a/docs/stories/story-12.13-fix-phase2-card-sync.md
+++ b/docs/stories/story-12.13-fix-phase2-card-sync.md
@@ -51,6 +51,16 @@ Key files to investigate:
 - `src/app/services/ketal-session/ketal-session.service.ts` — `updateCardsDoc()` method
 - `src/app/_components/game/` — game component Phase 2 template
 
+### Root Cause
+
+Both bugs shared the same root cause: `displayNewCard()` made multiple sequential `updateGame()` calls (via `selectCardOnPlayer`, `addPlayerSip`, `addDrinkingCard`/`addGivingCard`). The first call triggered `saveToAppwrite()` which set `_isSyncing = true`. All subsequent calls had their Appwrite sync skipped. When the first async save completed, the realtime callback overwrote local state with stale Appwrite data (missing the card additions from later calls).
+
+### Fix
+
+Refactored `displayNewCard()` to batch all Phase 2 mutations (deselect, player card selection, sip assignment, card array push, status update) into a single `updateGame()` call, followed by one `syncToAppwrite()` call. This ensures:
+- All state changes are applied atomically to the signal (Bug A fix)
+- The complete state including drinkingCards/givingCards is sent to Appwrite in one sync (Bug B fix)
+
 ---
 
 ## Change Log

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -792,9 +792,6 @@ export class GameService {
       return;
     }
 
-    game.givingCards.forEach((card) => (card.selected = false));
-    game.drinkingCards.forEach((card) => (card.selected = false));
-
     if (this.isNotAllSipsGiven() && game.drinkingCards.length > 0) {
       return;
     }
@@ -803,13 +800,66 @@ export class GameService {
     newCard.selected = true;
 
     const sipNb = this.getSipsNumber();
-    this.selectCardOnPlayer(sipNb, newCard);
-
     newCard.sips = sipNb;
-    this.saveCardAndSips(newCard, sipNb);
 
-    if (this.givingCards().length === 6) {
-      this.setStatus(2);
+    // Determine if this is a giving card BEFORE mutating
+    const isGiving = this.drinkingCards().length > this.givingCards().length;
+
+    // Batch all Phase 2 mutations into a single updateGame call to avoid
+    // the _isSyncing flag blocking intermediate Appwrite updates (Bug A + B)
+    this.updateGame((g) => {
+      // Deselect previous cards
+      g.givingCards.forEach((card) => (card.selected = false));
+      g.drinkingCards.forEach((card) => (card.selected = false));
+
+      // Mark matching player cards as selected and assign givenSips
+      g.players.forEach((player) => {
+        player.cards.forEach((card) => {
+          card.selected = card.value === newCard.value;
+          if (card.selected && this.isSummaryActivated() && isGiving && sipNb > 0) {
+            card.givenSips = sipNb;
+          }
+        });
+      });
+
+      // Add sips to players
+      g.players.forEach((player) => {
+        let sipTurnNb = 0;
+        player.cards.forEach((c) => {
+          if (c.value === newCard.value) {
+            sipTurnNb += sipNb;
+          }
+        });
+        if (sipTurnNb > 0) {
+          if (!player.cards || player.cards.length < 4) {
+            player.sips['drunk'] += sipTurnNb;
+          } else {
+            player.sips[!isGiving ? 'drunk' : 'given'] += sipTurnNb;
+          }
+        }
+      });
+
+      // Add the card to the appropriate array
+      if (isGiving) {
+        g.givingCards.push(newCard);
+      } else {
+        g.drinkingCards.push(newCard);
+      }
+
+      // Check if game is finished (6 giving cards)
+      if (g.givingCards.length === 6) {
+        g.status = 2;
+      }
+    });
+
+    // Sync to Appwrite in room mode (includes drinkingCards/givingCards)
+    if (this.gameMode() === 'room') {
+      this.syncToAppwrite();
+    }
+
+    // Finalize game stats if finished
+    if (this.status() === 2) {
+      this.finalizeGameStats();
     }
 
     return newCard;

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -429,15 +429,26 @@ export class GameService {
     });
 
     // Sync to Appwrite in room mode (AC1: setCardChoice persists in Appwrite)
+    // Fire-and-forget: errors are caught and logged, not blocking the UI flow
     if (this.gameMode() === 'room') {
-      this.syncToAppwrite();
+      this.syncToAppwrite().catch((err) => console.error('[GameService] setCardChoice sync failed:', err));
     }
   }
 
+  /**
+   * Add a card to the drinking cards array.
+   * Note: In Phase 2, the batched displayNewCard() path is used instead.
+   * This method is kept for direct unit testing and potential Phase 1 use.
+   */
   addDrinkingCard(card: CardType): void {
     this.updateGame((game) => game.drinkingCards.push(card));
   }
 
+  /**
+   * Add a card to the giving cards array.
+   * Note: In Phase 2, the batched displayNewCard() path is used instead.
+   * This method is kept for direct unit testing and potential Phase 1 use.
+   */
   addGivingCard(card: CardType): void {
     this.updateGame((game) => game.givingCards.push(card));
   }
@@ -459,8 +470,9 @@ export class GameService {
     });
 
     // Sync to Appwrite in room mode (AC2: addCardToPlayer persists in Appwrite)
+    // Fire-and-forget: errors are caught and logged, not blocking the UI flow
     if (this.gameMode() === 'room') {
-      this.syncToAppwrite();
+      this.syncToAppwrite().catch((err) => console.error('[GameService] addCardToPlayer sync failed:', err));
     }
   }
 
@@ -730,8 +742,9 @@ export class GameService {
 
     // Sync turn/phase/activePlayer changes to Appwrite in room mode
     // (AC3, AC4: pickCard updates session with new player/turn/phase)
+    // Fire-and-forget: errors are caught and logged, not blocking the UI flow
     if (this.gameMode() === 'room') {
-      this.syncToAppwrite();
+      this.syncToAppwrite().catch((err) => console.error('[GameService] pickCard sync failed:', err));
     }
   }
 
@@ -802,7 +815,10 @@ export class GameService {
     const sipNb = this.getSipsNumber();
     newCard.sips = sipNb;
 
-    // Determine if this is a giving card BEFORE mutating
+    // Determine if this is a giving card BEFORE mutating the game state.
+    // This is safe because JavaScript is single-threaded: no concurrent mutation
+    // can occur between reading the lengths and entering the updateGame closure.
+    // The value must be captured here because updateGame mutates the arrays.
     const isGiving = this.drinkingCards().length > this.givingCards().length;
 
     // Batch all Phase 2 mutations into a single updateGame call to avoid
@@ -813,8 +829,8 @@ export class GameService {
       g.drinkingCards.forEach((card) => (card.selected = false));
 
       // Mark matching player cards as selected and assign givenSips
-      g.players.forEach((player) => {
-        player.cards.forEach((card) => {
+      g.players?.forEach((player) => {
+        player.cards?.forEach((card) => {
           card.selected = card.value === newCard.value;
           if (card.selected && this.isSummaryActivated() && isGiving && sipNb > 0) {
             card.givenSips = sipNb;
@@ -823,9 +839,10 @@ export class GameService {
       });
 
       // Add sips to players
-      g.players.forEach((player) => {
+      g.players?.forEach((player) => {
+        player.sips ??= { drunk: 0, given: 0 };
         let sipTurnNb = 0;
-        player.cards.forEach((c) => {
+        player.cards?.forEach((c) => {
           if (c.value === newCard.value) {
             sipTurnNb += sipNb;
           }
@@ -853,8 +870,9 @@ export class GameService {
     });
 
     // Sync to Appwrite in room mode (includes drinkingCards/givingCards)
+    // Fire-and-forget: errors are caught and logged, not blocking the UI flow
     if (this.gameMode() === 'room') {
-      this.syncToAppwrite();
+      this.syncToAppwrite().catch((err) => console.error('[GameService] displayNewCard sync failed:', err));
     }
 
     // Finalize game stats if finished
@@ -865,6 +883,11 @@ export class GameService {
     return newCard;
   }
 
+  /**
+   * Add sips to all players whose cards match the given card value.
+   * Note: In Phase 2, the batched displayNewCard() path handles sips inline.
+   * This method is kept for direct unit testing.
+   */
   addSips(card: CardType, sipNb: number): void {
     this.players().forEach((player) => {
       let sipTurnNb = 0;
@@ -877,6 +900,11 @@ export class GameService {
     });
   }
 
+  /**
+   * Save a card and assign sips to matching players.
+   * Note: In Phase 2, the batched displayNewCard() path handles this inline.
+   * This method is kept for direct unit testing.
+   */
   saveCardAndSips(card: CardType, sipNb: number): void {
     this.addSips(card, sipNb);
     if (this.isGivingCard()) {


### PR DESCRIPTION
## Summary
- Fix cards not stacking in Phase 2 (replaced instead of added)
- Fix drinkingCards/givingCards not synced to Appwrite ketal_cards collection
- Root cause: multiple sequential updateGame() calls caused first sync to trigger realtime overwrite of subsequent local mutations
- Solution: batch all Phase 2 mutations into a single updateGame() call

## Test plan
- [x] TypeScript compilation passes
- [x] 974 tests pass
- [ ] E2E: Phase 2 cards stack correctly (counter increments)
- [ ] E2E: drinkingCards/givingCards appear in Appwrite