### PR TITLE
feat: add design system with CSS custom properties and theme support

### DIFF
--- a/src/_design-tokens.scss
+++ b/src/_design-tokens.scss
@@ -1,0 +1,193 @@
+// ============================
+// Design Tokens - Ketal
+// ============================
+
+// ===== Color Palette =====
+:root,
+[data-theme='light'] {
+  --color-bg-primary: #f8f9fa;
+  --color-bg-secondary: #ffffff;
+  --color-bg-surface: #f0f0f5;
+  --color-bg-elevated: #ffffff;
+
+  --color-suit-red: #dc2626;
+  --color-suit-black: #1e293b;
+  --color-drink: #dc2626;
+  --color-drink-bg: rgba(220, 38, 38, 0.1);
+  --color-give: #16a34a;
+  --color-give-bg: rgba(22, 163, 74, 0.1);
+  --color-accent-gold: #d97706;
+  --color-accent-primary: #4f46e5;
+
+  --color-text-primary: #1e293b;
+  --color-text-secondary: #475569;
+  --color-text-muted: #94a3b8;
+
+  --color-border: #e2e8f0;
+  --color-divider: #f1f5f9;
+
+  --color-success: #16a34a;
+  --color-warning: #d97706;
+  --color-error: #dc2626;
+  --color-info: #2563eb;
+}
+
+[data-theme='dark'] {
+  --color-bg-primary: #0a0a0f;
+  --color-bg-secondary: #12121a;
+  --color-bg-surface: #1a1a2e;
+  --color-bg-elevated: #242440;
+
+  --color-suit-red: #ef4444;
+  --color-suit-black: #e2e8f0;
+  --color-drink: #dc2626;
+  --color-drink-bg: rgba(220, 38, 38, 0.15);
+  --color-give: #22c55e;
+  --color-give-bg: rgba(34, 197, 94, 0.15);
+  --color-accent-gold: #f59e0b;
+  --color-accent-primary: #6366f1;
+
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #64748b;
+
+  --color-border: #2d2d4a;
+  --color-divider: #1e1e35;
+
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+  --color-info: #3b82f6;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --color-bg-primary: #0a0a0f;
+    --color-bg-secondary: #12121a;
+    --color-bg-surface: #1a1a2e;
+    --color-bg-elevated: #242440;
+
+    --color-suit-red: #ef4444;
+    --color-suit-black: #e2e8f0;
+    --color-drink: #dc2626;
+    --color-drink-bg: rgba(220, 38, 38, 0.15);
+    --color-give: #22c55e;
+    --color-give-bg: rgba(34, 197, 94, 0.15);
+    --color-accent-gold: #f59e0b;
+    --color-accent-primary: #6366f1;
+
+    --color-text-primary: #f1f5f9;
+    --color-text-secondary: #94a3b8;
+    --color-text-muted: #64748b;
+
+    --color-border: #2d2d4a;
+    --color-divider: #1e1e35;
+
+    --color-success: #22c55e;
+    --color-warning: #f59e0b;
+    --color-error: #ef4444;
+    --color-info: #3b82f6;
+  }
+}
+
+// ===== Typography =====
+:root {
+  --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    sans-serif;
+  --font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.75rem;
+  --font-size-3xl: 2.5rem;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --line-height-tight: 1.25;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.75;
+}
+
+// ===== Spacing =====
+:root {
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.15);
+  --shadow-glow: 0 0 0.5rem 0.25rem;
+}
+
+// ===== Animation =====
+:root {
+  --animation-fast: 150ms;
+  --animation-normal: 300ms;
+  --animation-slow: 500ms;
+
+  --ease-default: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-spring: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --animation-fast: 0ms;
+    --animation-normal: 0ms;
+    --animation-slow: 0ms;
+  }
+}
+
+.animate-none {
+  --animation-fast: 0ms;
+  --animation-normal: 0ms;
+  --animation-slow: 0ms;
+}
+
+// ===== Breakpoints (SCSS only - cannot be CSS custom properties in media queries) =====
+$bp-mobile: 375px;
+$bp-tablet: 768px;
+$bp-desktop: 1024px;
+$bp-wide: 1440px;
+
+@mixin mobile {
+  @media (min-width: $bp-mobile) {
+    @content;
+  }
+}
+@mixin tablet {
+  @media (min-width: $bp-tablet) {
+    @content;
+  }
+}
+@mixin desktop {
+  @media (min-width: $bp-desktop) {
+    @content;
+  }
+}
+@mixin wide {
+  @media (min-width: $bp-wide) {
+    @content;
+  }
+}

--- a/src/app/_shared/_components/playing-card/playing-card.component.scss
+++ b/src/app/_shared/_components/playing-card/playing-card.component.scss
@@ -16,12 +16,13 @@
   }
 
   &.emphasis {
-    box-shadow: 0 0 0.5rem 0.25rem rgba(127, 255, 212, 0.7);
+    box-shadow: var(--shadow-glow) var(--color-accent-gold);
     z-index: 1;
   }
 
   img {
     width: 100%;
     height: auto;
+    border-radius: var(--radius-md);
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8">
   <title>Ketal</title>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,5 @@
+@import 'design-tokens';
+
 /* You can add global styles to this file, and also import other style files */
 html, body {
   height: 100%;


### PR DESCRIPTION
## Summary
- Create design tokens file with complete color palette, typography, spacing, and animation tokens
- Support dark/light theme via `data-theme` attribute and `prefers-color-scheme` fallback
- Migrate playing-card component to use design tokens for emphasis glow and border-radius
- Set dark theme as default on the HTML element

## Changes
- **NEW**: `src/_design-tokens.scss` — all CSS custom properties and SCSS breakpoint mixins
- **MODIFIED**: `src/styles.scss` — imports design tokens before other styles
- **MODIFIED**: `src/index.html` — adds `data-theme="dark"` to HTML element
- **MODIFIED**: `playing-card.component.scss` — uses `var(--shadow-glow)`, `var(--color-accent-gold)`, `var(--radius-md)` instead of hardcoded values

## Test plan
- [ ] Verify SCSS compiles without errors
- [ ] Verify playing-card emphasis glow uses gold accent color from design tokens
- [ ] Verify dark theme is applied by default
- [ ] Verify light theme works when `data-theme="light"` is set on HTML element
- [ ] Verify `prefers-color-scheme` fallback works when no `data-theme` attribute is set
- [ ] Verify existing tests still pass