### PR TITLE
fix: remove orphaned git conflict markers from i18n files

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -27,7 +27,6 @@
   "Button_Delete": "Delete",
   "Button_NextCard": "Next",
   "Button_Restart": "Restart",
-<<<<<<< HEAD
   "Button_Display_Summary": "Display summary",
   "Remaining_Sips": "sips",
   "Label_Sip": "sip",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -25,7 +25,6 @@
   "Button_Delete": "Supprimer",
   "Button_NextCard": "Suivante",
   "Button_Restart": "Recommencer",
-<<<<<<< HEAD
   "Button_Display_Summary": "Afficher le résumé",
   "Button_In": "Entre",
   "Button_Out": "Extérieur",


### PR DESCRIPTION
## Summary
- Removes stale `<<<<<<< HEAD` markers left from a prior merge in `fr.json` and `en.json`
- These orphaned conflict markers broke JSON parsing and all i18n translations

## Test plan
- [x] Verified both `fr.json` and `en.json` parse as valid JSON after the fix