### PR TITLE
feat: Story 15.3 - Phase 1 prediction animations + UX polish

### DIFF
--- a/src/app/_shared/_components/footer/footer.component.html
+++ b/src/app/_shared/_components/footer/footer.component.html
@@ -1,8 +1,8 @@
 <div class="footer-wrapper">
   @if (!isHiddenPage()) {
     <!-- Phase 1: Prediction Panel -->
-    @if (gameSrv.isGameStarted() && [1, 2, 3, 4].includes(gameSrv.turn())) {
-      <div class="prediction-panel">
+    @if (gameSrv.isGameStarted() && ([1, 2, 3, 4].includes(gameSrv.turn()) || isAnimationLocked())) {
+      <div class="prediction-panel" [ngClass]="{ 'prediction-panel--animating': isAnimationLocked() }">
         @if (gameSrv.activePlayer(); as activePlayer) {
           <div class="prediction-panel__player prediction-panel__player--desktop">
             <img
@@ -16,26 +16,72 @@
           </div>
         }
 
-        <div class="prediction-panel__choices">
-          @if (gameSrv.turn() === 1) {
+        <!-- Turn content with transition wrapper -->
+        <div
+          class="prediction-panel__choices"
+          [ngClass]="{
+            'turn-slide-out': animationPhase() === 'transitioning',
+            'turn-slide-in': turnTransitioning() && animationPhase() === 'idle',
+          }"
+        >
+          <!-- Show animating turn during animation, otherwise current turn -->
+          @let displayTurn = isAnimationLocked() ? animatingTurn() : gameSrv.turn();
+
+          @if (displayTurn === 1) {
             <div class="prediction-panel__choices-row">
-              <button title="chooseRed" class="prediction-btn prediction-btn--red" (click)="chooseColor('red')">
+              <button
+                [attr.aria-label]="'game.turn1.red' | translate"
+                class="prediction-btn prediction-btn--red"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'red',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'red',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="chooseColor('red')"
+              >
                 <span class="prediction-btn__icon">&hearts;</span>
                 <span class="prediction-btn__label" [translate]="'game.turn1.red'"></span>
               </button>
-              <button title="chooseBlack" class="prediction-btn prediction-btn--black" (click)="chooseColor('black')">
+              <button
+                [attr.aria-label]="'game.turn1.black' | translate"
+                class="prediction-btn prediction-btn--black"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'black',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'black',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="chooseColor('black')"
+              >
                 <span class="prediction-btn__icon">&spades;</span>
                 <span class="prediction-btn__label" [translate]="'game.turn1.black'"></span>
               </button>
             </div>
           }
-          @if (gameSrv.turn() === 2) {
+          @if (displayTurn === 2) {
             <div class="prediction-panel__choices-row">
-              <button title="choosePlus" class="prediction-btn" (click)="plusOrMinus('plus')">
+              <button
+                [attr.aria-label]="'game.turn2.higher' | translate"
+                class="prediction-btn"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'plus',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'plus',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="plusOrMinus('plus')"
+              >
                 <span class="prediction-btn__icon prediction-btn__icon--up">&uarr;</span>
                 <span class="prediction-btn__label" [translate]="'game.turn2.higher'"></span>
               </button>
-              <button title="chooseMinus" class="prediction-btn" (click)="plusOrMinus('minus')">
+              <button
+                [attr.aria-label]="'game.turn2.lower' | translate"
+                class="prediction-btn"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'minus',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'minus',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="plusOrMinus('minus')"
+              >
                 <span class="prediction-btn__icon prediction-btn__icon--down">&darr;</span>
                 <span class="prediction-btn__label" [translate]="'game.turn2.lower'"></span>
               </button>
@@ -47,9 +93,18 @@
               }
             </div>
           }
-          @if (gameSrv.turn() === 3) {
+          @if (displayTurn === 3) {
             <div class="prediction-panel__choices-row">
-              <button title="chooseIn" class="prediction-btn prediction-btn--inout" (click)="inOut('in')">
+              <button
+                [attr.aria-label]="'game.turn3.in' | translate"
+                class="prediction-btn prediction-btn--inout"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'in',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'in',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="inOut('in')"
+              >
                 @for (card of gameSrv.activePlayer()?.cards; track $index; let i = $index) {
                   <div class="inout-card-wrapper">
                     <app-playing-card [card]="card"></app-playing-card>
@@ -62,7 +117,16 @@
                   </div>
                 }
               </button>
-              <button title="chooseOut" class="prediction-btn prediction-btn--inout" (click)="inOut('out')">
+              <button
+                [attr.aria-label]="'game.turn3.out' | translate"
+                class="prediction-btn prediction-btn--inout"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'out',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'out',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="inOut('out')"
+              >
                 @for (card of gameSrv.activePlayer()?.cards; track $index; let i = $index) {
                   <div class="inout-card-wrapper">
                     @if (i === 0) {
@@ -77,21 +141,91 @@
               </button>
             </div>
           }
-          @if (gameSrv.turn() === 4) {
+          @if (displayTurn === 4) {
             <div class="prediction-panel__choices-row">
-              <button title="chooseHearts" class="prediction-btn prediction-btn--suit" (click)="chooseSuit('hearts')">
+              <button
+                [attr.aria-label]="'game.turn4.hearts' | translate"
+                class="prediction-btn prediction-btn--suit"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'hearts',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'hearts',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="chooseSuit('hearts')"
+              >
                 <span class="prediction-btn__suit-icon prediction-btn__suit-icon--red">&hearts;</span>
               </button>
-              <button title="chooseDiams" class="prediction-btn prediction-btn--suit" (click)="chooseSuit('diams')">
+              <button
+                [attr.aria-label]="'game.turn4.diamonds' | translate"
+                class="prediction-btn prediction-btn--suit"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'diams',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'diams',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="chooseSuit('diams')"
+              >
                 <span class="prediction-btn__suit-icon prediction-btn__suit-icon--red">&diams;</span>
               </button>
-              <button title="chooseSpades" class="prediction-btn prediction-btn--suit" (click)="chooseSuit('spades')">
+              <button
+                [attr.aria-label]="'game.turn4.spades' | translate"
+                class="prediction-btn prediction-btn--suit"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'spades',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'spades',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="chooseSuit('spades')"
+              >
                 <span class="prediction-btn__suit-icon">&spades;</span>
               </button>
-              <button title="chooseClubs" class="prediction-btn prediction-btn--suit" (click)="chooseSuit('clubs')">
+              <button
+                [attr.aria-label]="'game.turn4.clubs' | translate"
+                class="prediction-btn prediction-btn--suit"
+                [ngClass]="{
+                  'prediction-btn--selected': selectedChoice() === 'clubs',
+                  'prediction-btn--not-selected': selectedChoice() !== null && selectedChoice() !== 'clubs',
+                }"
+                [disabled]="isAnimationLocked()"
+                (click)="chooseSuit('clubs')"
+              >
                 <span class="prediction-btn__suit-icon">&clubs;</span>
               </button>
             </div>
+          }
+
+          <!-- Card reveal after prediction -->
+          @if (['revealing', 'result', 'transitioning'].includes(animationPhase())) {
+            <div
+              class="card-reveal"
+              [ngClass]="{
+                'card-reveal--correct': animationPhase() === 'result' && predictionCorrect(),
+                'card-reveal--incorrect': animationPhase() === 'result' && predictionCorrect() === false,
+                'card-reveal--shake': animationPhase() === 'result' && predictionCorrect() === false,
+              }"
+            >
+              <div
+                class="card-reveal__flip"
+                [ngClass]="{ 'card-reveal__flip--revealed': animationPhase() !== 'revealing' }"
+              >
+                <div class="card-reveal__back"></div>
+                <div class="card-reveal__front">
+                  @if (revealedCard(); as card) {
+                    <img [src]="card.img" [alt]="(card.value ?? '') + ' ' + (card.suit ?? '')" />
+                  }
+                </div>
+              </div>
+            </div>
+            <!-- Screen reader announcement for prediction result -->
+            @if (animationPhase() === 'result') {
+              <div class="visually-hidden" aria-live="polite">
+                {{
+                  predictionCorrect()
+                    ? ('game.prediction.correct' | translate)
+                    : ('game.prediction.incorrect' | translate)
+                }}
+              </div>
+            }
           }
         </div>
       </div>

--- a/src/app/_shared/_components/footer/footer.component.html
+++ b/src/app/_shared/_components/footer/footer.component.html
@@ -25,7 +25,7 @@
           }"
         >
           <!-- Show animating turn during animation, otherwise current turn -->
-          @let displayTurn = isAnimationLocked() ? animatingTurn() : gameSrv.turn();
+          @let displayTurn = isAnimationLocked() && animatingTurn() !== null ? animatingTurn() : gameSrv.turn();
 
           @if (displayTurn === 1) {
             <div class="prediction-panel__choices-row">
@@ -200,8 +200,8 @@
               class="card-reveal"
               [ngClass]="{
                 'card-reveal--correct': animationPhase() === 'result' && predictionCorrect(),
-                'card-reveal--incorrect': animationPhase() === 'result' && predictionCorrect() === false,
-                'card-reveal--shake': animationPhase() === 'result' && predictionCorrect() === false,
+                'card-reveal--incorrect': animationPhase() === 'result' && predictionIncorrect(),
+                'card-reveal--shake': animationPhase() === 'result' && predictionIncorrect(),
               }"
             >
               <div

--- a/src/app/_shared/_components/footer/footer.component.scss
+++ b/src/app/_shared/_components/footer/footer.component.scss
@@ -128,7 +128,12 @@
   font-weight: var(--font-weight-semibold);
   cursor: pointer;
   transition: all var(--animation-normal) var(--ease-spring);
-  will-change: transform, opacity, box-shadow;
+  &:hover:not(:disabled),
+  &:active:not(:disabled),
+  &--selected,
+  &--not-selected {
+    will-change: transform, opacity, box-shadow;
+  }
   &:hover:not(:disabled) {
     border-color: var(--color-accent-primary);
     background: color-mix(in srgb, var(--color-accent-primary) 10%, transparent);
@@ -448,4 +453,16 @@
   width: 90%;
   text-align: center;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+// === Reduced motion support ===
+@media (prefers-reduced-motion: reduce) {
+  .prediction-btn,
+  .card-reveal__flip,
+  .stepper__icon,
+  .stepper__label,
+  .stepper__line {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }

--- a/src/app/_shared/_components/footer/footer.component.scss
+++ b/src/app/_shared/_components/footer/footer.component.scss
@@ -40,7 +40,7 @@
     display: none;
   }
   .prediction-panel {
-    padding: var(--space-2);
+    padding: var(--space-3) var(--space-2) var(--space-2);
     gap: var(--space-2);
     margin-top: 0;
     border-radius: 0;
@@ -59,14 +59,17 @@
   }
   .prediction-btn {
     min-width: 64px;
-    min-height: 56px;
+    min-height: 48px;
     padding: var(--space-1) var(--space-2);
   }
   .prediction-btn__icon {
     font-size: 1.25rem;
   }
   .prediction-btn--suit {
-    min-width: 48px;
+    min-width: 56px;
+    min-height: 56px;
+  }
+  .prediction-btn--inout {
     min-height: 48px;
   }
   .prediction-panel__choices-row {
@@ -124,21 +127,39 @@
   color: var(--color-text-primary);
   font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  transition: all 0.15s ease;
-  &:hover {
+  transition: all var(--animation-normal) var(--ease-spring);
+  will-change: transform, opacity, box-shadow;
+  &:hover:not(:disabled) {
     border-color: var(--color-accent-primary);
     background: color-mix(in srgb, var(--color-accent-primary) 10%, transparent);
     transform: translateY(-2px);
     box-shadow: 0 4px 12px color-mix(in srgb, var(--color-accent-primary) 20%, transparent);
   }
-  &:active {
-    transform: scale(0.96);
+  &:active:not(:disabled) {
+    transform: scale(0.95);
     box-shadow: none;
+  }
+  &:disabled {
+    cursor: default;
   }
   @media (max-width: 767px) {
     min-width: 68px;
     min-height: 60px;
     padding: var(--space-2);
+  }
+
+  // Selection animation states
+  &--selected {
+    transform: scale(1.05);
+    border-color: var(--color-accent-primary);
+    box-shadow: 0 0 20px color-mix(in srgb, var(--color-accent-primary) 40%, transparent);
+    z-index: 1;
+  }
+  &--not-selected {
+    opacity: 0.5;
+    transform: scale(0.95);
+    pointer-events: none;
+    border-color: rgba(255, 255, 255, 0.3);
   }
 }
 
@@ -204,6 +225,12 @@
     background: #1a1a1a;
     transform: translateY(-2px);
   }
+  &.prediction-btn--not-selected {
+    opacity: 1;
+    background: #444;
+    border-color: #666;
+    color: rgba(255, 255, 255, 0.5);
+  }
 }
 
 .prediction-btn--suit {
@@ -244,6 +271,161 @@
 }
 .space-below {
   margin-bottom: 10px;
+}
+
+// === Card flip 3D reveal ===
+.card-reveal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 1000px;
+  margin-left: var(--space-3);
+
+  &__flip {
+    position: relative;
+    width: 70px;
+    height: 98px;
+    transform-style: preserve-3d;
+    transition: transform 400ms var(--ease-in-out);
+    will-change: transform;
+
+    &--revealed {
+      transform: rotateY(180deg);
+    }
+
+    @media (max-width: 767px) {
+      width: 50px;
+      height: 70px;
+    }
+  }
+
+  &__back,
+  &__front {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+
+  &__back {
+    background: linear-gradient(135deg, var(--color-bg-elevated) 0%, var(--color-accent-primary) 100%);
+    border: 2px solid var(--color-border);
+  }
+
+  &__front {
+    transform: rotateY(180deg);
+    background: var(--color-bg-surface);
+    border: 2px solid var(--color-border);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border-radius: var(--radius-sm);
+    }
+  }
+
+  // Result feedback
+  &--correct {
+    .card-reveal__front {
+      border-color: var(--color-success);
+      box-shadow: 0 0 16px color-mix(in srgb, var(--color-success) 50%, transparent);
+    }
+  }
+
+  &--incorrect {
+    .card-reveal__front {
+      border-color: var(--color-error);
+      box-shadow: 0 0 16px color-mix(in srgb, var(--color-error) 50%, transparent);
+    }
+  }
+
+  &--shake {
+    animation: shake 400ms var(--ease-default);
+  }
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-6px);
+  }
+  40% {
+    transform: translateX(6px);
+  }
+  60% {
+    transform: translateX(-4px);
+  }
+  80% {
+    transform: translateX(4px);
+  }
+}
+
+// === Turn transition animations ===
+.prediction-panel__choices {
+  position: relative;
+
+  // Only clip overflow during slide transitions, not during selection/reveal
+  &.turn-slide-out,
+  &.turn-slide-in {
+    overflow: hidden;
+  }
+}
+
+.turn-slide-out {
+  animation: slideOut var(--animation-normal) var(--ease-in-out) forwards;
+}
+
+.turn-slide-in {
+  animation: slideIn var(--animation-normal) var(--ease-in-out) forwards;
+}
+
+@keyframes slideOut {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(-30%);
+    opacity: 0;
+  }
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(30%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+// Red/black selected variants
+.prediction-btn--red.prediction-btn--selected {
+  box-shadow: 0 0 24px rgba(220, 38, 38, 0.5);
+  border-color: #ef4444;
+}
+
+.prediction-btn--black.prediction-btn--selected {
+  box-shadow: 0 0 24px color-mix(in srgb, var(--color-accent-primary) 50%, transparent);
+  border-color: var(--color-accent-primary);
+}
+
+// Suit button selected glow colors
+.prediction-btn--suit.prediction-btn--selected {
+  .prediction-btn__suit-icon--red {
+    text-shadow: 0 0 12px rgba(220, 38, 38, 0.6);
+  }
+  .prediction-btn__suit-icon:not(.prediction-btn__suit-icon--red) {
+    text-shadow: 0 0 12px rgba(0, 0, 0, 0.4);
+  }
 }
 
 .quit-confirm-overlay {

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, ViewChild, inject } from '@angular/core';
+import { Component, Input, ViewChild, inject, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
+import { NgClass } from '@angular/common';
 import { FontAwesomeIconsModule } from '../../../font-awesome.module';
 import { AuthService } from '../../../services/auth/auth.service';
 import { GameService } from '../../../services/game/game.service';
@@ -11,6 +12,9 @@ import { DrinkChoiceEnum } from '../../_models/enums/drink_choice.enum';
 import { ToastComponent } from '../toast/toast.component';
 import { PlayingCardComponent } from '../playing-card/playing-card.component';
 import { AccountGateModalComponent } from '../../../_components/auth/account-gate-modal/account-gate-modal.component';
+
+/** Animation phase for prediction flow */
+type AnimationPhase = 'idle' | 'selected' | 'revealing' | 'result' | 'transitioning';
 
 /** Routes where the game footer should be hidden */
 const HIDDEN_ROUTES = ['/login', '/register', '/forgot-password', '/room', '/home'];
@@ -23,7 +27,14 @@ const PENDING_SUMMARY_KEY = 'pendingSummary';
   templateUrl: './footer.component.html',
   styleUrls: ['./footer.component.scss'],
   standalone: true,
-  imports: [TranslateModule, FontAwesomeIconsModule, ToastComponent, PlayingCardComponent, AccountGateModalComponent],
+  imports: [
+    TranslateModule,
+    FontAwesomeIconsModule,
+    NgClass,
+    ToastComponent,
+    PlayingCardComponent,
+    AccountGateModalComponent,
+  ],
 })
 export class FooterComponent {
   private readonly router = inject(Router);
@@ -40,6 +51,23 @@ export class FooterComponent {
 
   /** Guard flag to prevent double-click on beginGame */
   private _beginGameInProgress = false;
+
+  // === Animation state for prediction flow ===
+  readonly animationPhase = signal<AnimationPhase>('idle');
+  readonly selectedChoice = signal<string | null>(null);
+  readonly revealedCard = signal<CardType | null>(null);
+  readonly predictionCorrect = signal<boolean | null>(null);
+  /** The turn number during animation (preserved while game state advances) */
+  readonly animatingTurn = signal<number>(0);
+  /** Track if we're transitioning between turns */
+  readonly turnTransitioning = signal(false);
+
+  /** Whether the prediction panel is locked during animation */
+  readonly isAnimationLocked = computed(() => this.animationPhase() !== 'idle');
+
+  /** Whether the user prefers reduced motion */
+  private readonly prefersReducedMotion =
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   /** Reference card for Turn 2 (the card drawn in Turn 1 for the active player) */
   getReferenceCard(): CardType | null {
@@ -61,19 +89,85 @@ export class FooterComponent {
   }
 
   chooseColor(color: string) {
-    this.gameSrv.setChoiceAndPickCard(DrinkChoiceEnum.Color, color);
+    this.animatedChoice(DrinkChoiceEnum.Color, color);
   }
 
   plusOrMinus(selection: string) {
-    this.gameSrv.setChoiceAndPickCard(DrinkChoiceEnum.PlusOrMinus, selection);
+    this.animatedChoice(DrinkChoiceEnum.PlusOrMinus, selection);
   }
 
   inOut(selection: string) {
-    this.gameSrv.setChoiceAndPickCard(DrinkChoiceEnum.InAndOut, selection);
+    this.animatedChoice(DrinkChoiceEnum.InAndOut, selection);
   }
 
   chooseSuit(selection: string) {
-    this.gameSrv.setChoiceAndPickCard(DrinkChoiceEnum.Suit, selection);
+    this.animatedChoice(DrinkChoiceEnum.Suit, selection);
+  }
+
+  /**
+   * Orchestrates the prediction animation sequence:
+   * 1. Button selection highlight (200ms)
+   * 2. Card flip reveal (400ms)
+   * 3. Result feedback - correct/incorrect (600ms)
+   * 4. Slide transition to next turn (300ms)
+   *
+   * When prefers-reduced-motion is active, delays are minimized.
+   */
+  private animatedChoice(choiceEnum: DrinkChoiceEnum, selection: string): void {
+    if (this.isAnimationLocked()) {
+      return;
+    }
+
+    const currentTurn = this.gameSrv.turn();
+    const activePlayerId = this.gameSrv.activePlayer()?.id;
+
+    // Timing: respect prefers-reduced-motion
+    const t = this.prefersReducedMotion
+      ? { select: 0, reveal: 0, result: 100, transition: 0 }
+      : { select: 200, reveal: 400, result: 600, transition: 300 };
+
+    // Phase 1: Button selected
+    this.animatingTurn.set(currentTurn);
+    this.selectedChoice.set(selection);
+    this.animationPhase.set('selected');
+
+    setTimeout(() => {
+      // Execute the actual game logic
+      this.gameSrv.setChoiceAndPickCard(choiceEnum, selection);
+
+      // Get the drawn card and result
+      const players = this.gameSrv.players();
+      const player = players.find((p) => p.id === activePlayerId);
+      const drawnCard = player?.cards[player.cards.length - 1] ?? null;
+      const sips = activePlayerId ? (this.gameSrv.lastTurnSips()[activePlayerId] ?? 0) : 0;
+
+      this.revealedCard.set(drawnCard);
+      this.predictionCorrect.set(sips === 0);
+
+      // Phase 2: Card flip reveal
+      this.animationPhase.set('revealing');
+
+      setTimeout(() => {
+        // Phase 3: Show result
+        this.animationPhase.set('result');
+
+        setTimeout(() => {
+          // Phase 4: Slide transition
+          this.animationPhase.set('transitioning');
+          this.turnTransitioning.set(true);
+
+          setTimeout(() => {
+            // Reset all animation state
+            this.animationPhase.set('idle');
+            this.selectedChoice.set(null);
+            this.revealedCard.set(null);
+            this.predictionCorrect.set(null);
+            this.animatingTurn.set(0);
+            this.turnTransitioning.set(false);
+          }, t.transition);
+        }, t.result);
+      }, t.reveal);
+    }, t.select);
   }
 
   async restartGame(): Promise<void> {

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, inject, signal, computed } from '@angular/core';
+import { Component, Input, ViewChild, OnDestroy, inject, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgClass } from '@angular/common';
@@ -36,7 +36,7 @@ const PENDING_SUMMARY_KEY = 'pendingSummary';
     AccountGateModalComponent,
   ],
 })
-export class FooterComponent {
+export class FooterComponent implements OnDestroy {
   private readonly router = inject(Router);
   private readonly authService = inject(AuthService);
   readonly gameSrv = inject(GameService);
@@ -57,17 +57,27 @@ export class FooterComponent {
   readonly selectedChoice = signal<string | null>(null);
   readonly revealedCard = signal<CardType | null>(null);
   readonly predictionCorrect = signal<boolean | null>(null);
-  /** The turn number during animation (preserved while game state advances) */
-  readonly animatingTurn = signal<number>(0);
+  /** The turn number during animation (null when not animating) */
+  readonly animatingTurn = signal<number | null>(null);
   /** Track if we're transitioning between turns */
   readonly turnTransitioning = signal(false);
 
   /** Whether the prediction panel is locked during animation */
   readonly isAnimationLocked = computed(() => this.animationPhase() !== 'idle');
+  /** Convenience computed for incorrect prediction check in template */
+  readonly predictionIncorrect = computed(() => this.predictionCorrect() === false);
 
   /** Whether the user prefers reduced motion */
   private readonly prefersReducedMotion =
     typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /** Active timeout IDs for animation cleanup on destroy */
+  private readonly _animationTimers: ReturnType<typeof setTimeout>[] = [];
+
+  ngOnDestroy(): void {
+    this._animationTimers.forEach((id) => clearTimeout(id));
+    this._animationTimers.length = 0;
+  }
 
   /** Reference card for Turn 2 (the card drawn in Turn 1 for the active player) */
   getReferenceCard(): CardType | null {
@@ -131,43 +141,54 @@ export class FooterComponent {
     this.selectedChoice.set(selection);
     this.animationPhase.set('selected');
 
-    setTimeout(() => {
+    this._scheduleTimer(() => {
       // Execute the actual game logic
       this.gameSrv.setChoiceAndPickCard(choiceEnum, selection);
 
-      // Get the drawn card and result
+      // Get the drawn card and result (read sips from card directly to avoid race condition)
       const players = this.gameSrv.players();
       const player = players.find((p) => p.id === activePlayerId);
       const drawnCard = player?.cards[player.cards.length - 1] ?? null;
-      const sips = activePlayerId ? (this.gameSrv.lastTurnSips()[activePlayerId] ?? 0) : 0;
 
       this.revealedCard.set(drawnCard);
-      this.predictionCorrect.set(sips === 0);
+      this.predictionCorrect.set((drawnCard?.sips ?? 0) === 0);
 
       // Phase 2: Card flip reveal
       this.animationPhase.set('revealing');
 
-      setTimeout(() => {
+      this._scheduleTimer(() => {
         // Phase 3: Show result
         this.animationPhase.set('result');
 
-        setTimeout(() => {
+        this._scheduleTimer(() => {
           // Phase 4: Slide transition
           this.animationPhase.set('transitioning');
           this.turnTransitioning.set(true);
 
-          setTimeout(() => {
+          this._scheduleTimer(() => {
             // Reset all animation state
             this.animationPhase.set('idle');
             this.selectedChoice.set(null);
             this.revealedCard.set(null);
             this.predictionCorrect.set(null);
-            this.animatingTurn.set(0);
+            this.animatingTurn.set(null);
             this.turnTransitioning.set(false);
           }, t.transition);
         }, t.result);
       }, t.reveal);
     }, t.select);
+  }
+
+  /** Schedule a timer and track it for cleanup on destroy */
+  private _scheduleTimer(fn: () => void, ms: number): void {
+    const id = setTimeout(() => {
+      const idx = this._animationTimers.indexOf(id);
+      if (idx !== -1) {
+        this._animationTimers.splice(idx, 1);
+      }
+      fn();
+    }, ms);
+    this._animationTimers.push(id);
   }
 
   async restartGame(): Promise<void> {

--- a/src/app/_shared/_components/game-progress/game-progress.component.html
+++ b/src/app/_shared/_components/game-progress/game-progress.component.html
@@ -1,20 +1,26 @@
 <div class="game-progress">
   @if (phase() === 1) {
-    <span class="phase-label">{{ 'game.progress.phase1' | translate }}</span>
-    <div class="stepper-dots">
-      @for (step of [1, 2, 3, 4]; track step) {
-        <span class="stepper-dot" [class.completed]="isStepCompleted(step)" [class.active]="isStepActive(step)">
-          @if (isStepCompleted(step)) {
-            <span class="dot-filled"></span>
-          } @else if (isStepActive(step)) {
-            <span class="dot-active"></span>
-          } @else {
-            <span class="dot-empty"></span>
-          }
-        </span>
+    <div class="stepper">
+      @for (step of steps; track step.num) {
+        @if (step.num > 1) {
+          <div class="stepper__line" [class.stepper__line--completed]="isStepCompleted(step.num)"></div>
+        }
+        <div
+          class="stepper__step"
+          [class.stepper__step--completed]="isStepCompleted(step.num)"
+          [class.stepper__step--active]="isStepActive(step.num)"
+        >
+          <div class="stepper__icon">
+            @if (isStepCompleted(step.num)) {
+              <span class="stepper__check">✓</span>
+            } @else {
+              <span class="stepper__symbol">{{ step.icon }}</span>
+            }
+          </div>
+          <span class="stepper__label">{{ step.labelKey | translate }}</span>
+        </div>
       }
     </div>
-    <span class="turn-label">{{ currentTurnKey() | translate }}</span>
   } @else if (phase() === 2) {
     <span class="phase-label">{{ 'game.progress.phase2' | translate }}</span>
     <div class="phase2-progress">

--- a/src/app/_shared/_components/game-progress/game-progress.component.scss
+++ b/src/app/_shared/_components/game-progress/game-progress.component.scss
@@ -4,58 +4,122 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.4rem 0.75rem;
-  background-color: rgba(0, 0, 0, 0.1);
-  border-radius: 0.5rem;
+  background-color: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
 }
 
-.phase-label {
+// === Stepper ===
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  width: 100%;
+  justify-content: center;
+}
+
+.stepper__step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  flex-shrink: 0;
+}
+
+.stepper__icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-surface);
+  border: 2px solid var(--color-border);
+  transition: all var(--animation-normal) var(--ease-spring);
   font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--bs-primary, #0d6efd);
-  white-space: nowrap;
 
   @media (max-width: 767px) {
+    width: 1.8rem;
+    height: 1.8rem;
     font-size: 0.75rem;
   }
 }
 
-.stepper-dots {
-  display: flex;
-  gap: 0.4rem;
-  align-items: center;
+.stepper__symbol {
+  line-height: 1;
 }
 
-.stepper-dot {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  .dot-filled,
-  .dot-active,
-  .dot-empty {
-    display: inline-block;
-    width: 0.6rem;
-    height: 0.6rem;
-    border-radius: 50%;
-    transition: all 0.2s ease;
-  }
-  .dot-filled {
-    background-color: var(--bs-success, #198754);
-  }
-  .dot-active {
-    background-color: var(--bs-primary, #0d6efd);
-    box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25);
-  }
-  .dot-empty {
-    background-color: var(--bs-secondary, #6c757d);
-    opacity: 0.4;
-  }
-}
-
-.turn-label {
+.stepper__check {
+  color: #fff;
+  font-weight: bold;
   font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--bs-body-color, #212529);
+  line-height: 1;
+}
+
+.stepper__label {
+  font-size: 0.65rem;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  transition: color var(--animation-normal) var(--ease-default);
+
+  @media (max-width: 767px) {
+    font-size: 0.65rem;
+  }
+}
+
+// Connecting line between steps
+.stepper__line {
+  flex: 1;
+  height: 2px;
+  min-width: 1.5rem;
+  max-width: 3rem;
+  background: var(--color-border);
+  margin: 0 0.15rem;
+  margin-bottom: 1rem; // align with icon, not label
+  border-radius: 1px;
+  transition: background var(--animation-normal) var(--ease-default);
+
+  @media (max-width: 767px) {
+    min-width: 1rem;
+    max-width: 2rem;
+    margin-bottom: 0.8rem;
+  }
+
+  &--completed {
+    background: var(--color-success);
+  }
+}
+
+// Step states
+.stepper__step--completed {
+  .stepper__icon {
+    background: var(--color-success);
+    border-color: var(--color-success);
+  }
+  .stepper__label {
+    color: var(--color-success);
+  }
+}
+
+.stepper__step--active {
+  .stepper__icon {
+    border-color: var(--color-accent-primary);
+    background: color-mix(in srgb, var(--color-accent-primary) 15%, transparent);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--color-accent-primary) 40%, transparent);
+  }
+  .stepper__label {
+    color: var(--color-accent-primary);
+    font-weight: var(--font-weight-semibold);
+  }
+}
+
+// === Phase 2 ===
+.phase-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-accent-primary);
+  white-space: nowrap;
 
   @media (max-width: 767px) {
     font-size: 0.75rem;
@@ -75,11 +139,11 @@
 
 .progress-label {
   font-size: 0.8rem;
-  color: var(--bs-body-color, #212529);
+  color: var(--color-text-secondary);
 }
 
 .progress-value {
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--bs-primary, #0d6efd);
+  color: var(--color-accent-primary);
 }

--- a/src/app/_shared/_components/game-progress/game-progress.component.ts
+++ b/src/app/_shared/_components/game-progress/game-progress.component.ts
@@ -28,22 +28,13 @@ export class GameProgressComponent {
   /** Total cards in phase 2 (drinking + giving) */
   readonly totalPhase2Cards = computed(() => this.drinkingCardsCount() + this.givingCardsCount());
 
-  /** Phase 1 turn labels translation keys */
-  readonly phase1TurnKeys = [
-    'game.progress.turn.color',
-    'game.progress.turn.plusMinus',
-    'game.progress.turn.inOut',
-    'game.progress.turn.suit',
+  /** Step definitions with icons and label keys */
+  readonly steps = [
+    { num: 1, icon: '🔴', labelKey: 'game.progress.turn.color' },
+    { num: 2, icon: '↕', labelKey: 'game.progress.turn.plusMinus' },
+    { num: 3, icon: '↔', labelKey: 'game.progress.turn.inOut' },
+    { num: 4, icon: '♠', labelKey: 'game.progress.turn.suit' },
   ];
-
-  /** Get translation key for current turn label */
-  readonly currentTurnKey = computed(() => {
-    const currentTurn = this.turn();
-    if (currentTurn >= 1 && currentTurn <= 4) {
-      return this.phase1TurnKeys[currentTurn - 1];
-    }
-    return '';
-  });
 
   /** Check if a step is completed in phase 1 */
   isStepCompleted(step: number): boolean {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -204,6 +204,20 @@
       "lower": "Lower",
       "referenceHint": "Compared to your card:"
     },
+    "turn3": {
+      "in": "In",
+      "out": "Out"
+    },
+    "turn4": {
+      "hearts": "Hearts",
+      "diamonds": "Diamonds",
+      "spades": "Spades",
+      "clubs": "Clubs"
+    },
+    "prediction": {
+      "correct": "Prediction correct",
+      "incorrect": "Prediction incorrect"
+    },
     "progress": {
       "phase1": "Phase 1: Predictions",
       "phase2": "Phase 2: Distribution",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -208,6 +208,20 @@
       "lower": "Plus bas",
       "referenceHint": "Par rapport à ta carte :"
     },
+    "turn3": {
+      "in": "Entre",
+      "out": "Dehors"
+    },
+    "turn4": {
+      "hearts": "Cœur",
+      "diamonds": "Carreau",
+      "spades": "Pique",
+      "clubs": "Trèfle"
+    },
+    "prediction": {
+      "correct": "Prédiction correcte",
+      "incorrect": "Prédiction incorrecte"
+    },
     "progress": {
       "phase1": "Phase 1: Prédictions",
       "phase2": "Phase 2: Distribution",


### PR DESCRIPTION
## Summary
- **Animation state machine** for Phase 1 predictions: idle → selected (scale+glow) → revealing (card flip 3D) → result (green/red+shake feedback) → transitioning (slide) → idle
- **Redesigned stepper** with turn icons (🔴↕↔♠), connection lines, checkmarks on completed steps, glow on active
- **Visual bug fixes**: overflow clipping during selection, invisible black button on dark background, broken card flip 3D
- **UX review fixes**: prefers-reduced-motion in JS timers, aria-live result announcements, stepper readability, touch targets 56px+, accent glow on black button

## Files changed
- `footer.component.ts/html/scss` — animation state machine, selection states, card flip, turn transitions
- `game-progress.component.ts/html/scss` — stepper redesign with icons and states
- `fr.json` / `en.json` — i18n keys for ARIA labels and prediction results

## Test plan
- [ ] Start a local game with 2+ players
- [ ] Verify Rouge/Noir buttons animate on selection (scale+glow on selected, fade on other)
- [ ] Verify card flip 3D shows back then reveals front
- [ ] Verify green border on correct prediction, red+shake on incorrect
- [ ] Verify stepper shows checkmarks on completed steps, glow on active
- [ ] Test all 4 turns (color, higher/lower, in/out, suit)
- [ ] Test on mobile (375px) — touch targets, fixed footer, no overflow clipping
- [ ] Test with prefers-reduced-motion enabled — animations should be instant
- [ ] Verify screen reader announces prediction results (aria-live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)