### PR TITLE
feat: Story 15.4 Phase 2 distribution redesign

### DIFF
--- a/src/_design-tokens.scss
+++ b/src/_design-tokens.scss
@@ -16,6 +16,8 @@
   --color-drink-bg: rgba(220, 38, 38, 0.1);
   --color-give: #16a34a;
   --color-give-bg: rgba(22, 163, 74, 0.1);
+  --color-give-event: #be185d;
+  --color-give-event-bg: rgba(236, 72, 153, 0.14);
   --color-accent-gold: #d97706;
   --color-accent-primary: #4f46e5;
 
@@ -44,6 +46,8 @@
   --color-drink-bg: rgba(220, 38, 38, 0.15);
   --color-give: #22c55e;
   --color-give-bg: rgba(34, 197, 94, 0.15);
+  --color-give-event: #f472b6;
+  --color-give-event-bg: rgba(236, 72, 153, 0.2);
   --color-accent-gold: #f59e0b;
   --color-accent-primary: #6366f1;
 
@@ -73,6 +77,8 @@
     --color-drink-bg: rgba(220, 38, 38, 0.15);
     --color-give: #22c55e;
     --color-give-bg: rgba(34, 197, 94, 0.15);
+    --color-give-event: #f472b6;
+    --color-give-event-bg: rgba(236, 72, 153, 0.2);
     --color-accent-gold: #f59e0b;
     --color-accent-primary: #6366f1;
 
@@ -92,8 +98,7 @@
 
 // ===== Typography =====
 :root {
-  --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    sans-serif;
+  --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
 
   --font-size-xs: 0.75rem;

--- a/src/app/_components/game/main-game/main-game.component.scss
+++ b/src/app/_components/game/main-game/main-game.component.scss
@@ -34,10 +34,13 @@
   grid-template-columns: 1fr;
   gap: var(--space-3);
   padding: var(--space-2) 0;
+  // Reserve space for the Phase 2 draw panel on mobile
+  padding-bottom: 160px;
   max-width: 900px;
   margin: 0 auto;
 
   @media (min-width: 768px) {
     grid-template-columns: repeat(2, 1fr);
+    padding-bottom: var(--space-2);
   }
 }

--- a/src/app/_components/players/player-card/player-card.component.html
+++ b/src/app/_components/players/player-card/player-card.component.html
@@ -40,6 +40,7 @@
     [ngClass]="{
       'player-card--active': isActive,
       'player-card--inactive': !isActive && hasActivePlayer,
+      'player-card--match': matchHighlight(),
     }"
   >
     <!-- Header: avatar + name + sips -->
@@ -58,10 +59,20 @@
       </div>
       <span class="player-card__name">{{ player.name }}</span>
       <div class="player-card__sips" (click)="openPlayerGivenSipsModal(player)">
-        <span class="player-card__sip-badge player-card__sip-badge--drink" [class.sip-bounce]="sipBounce()">
+        <span
+          class="player-card__sip-badge player-card__sip-badge--drink"
+          [class.sip-bounce]="sipBounce()"
+          [class.sip-shake]="sipShake()"
+          [attr.data-severity]="sipSeverity()"
+        >
           {{ sipsDrunk() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
         </span>
-        <span class="player-card__sip-badge player-card__sip-badge--give" [class.sip-bounce]="sipBounce()">
+        <span
+          class="player-card__sip-badge player-card__sip-badge--give"
+          [class.sip-bounce]="sipBounce()"
+          [class.sip-shake]="sipShake()"
+          [attr.data-severity]="sipSeverity()"
+        >
           {{ sipsGiven() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
         </span>
       </div>

--- a/src/app/_components/players/player-card/player-card.component.html
+++ b/src/app/_components/players/player-card/player-card.component.html
@@ -26,10 +26,20 @@
       <span class="player-card__sip-badge player-card__sip-badge--give">
         {{ sipsGiven() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
       </span>
+      @if (sipsGivenPending() > 0) {
+        <span class="player-card__sip-badge player-card__sip-badge--give-pending">
+          {{ sipsGivenPending() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
+        </span>
+      }
     </div>
     @if (lastTurnSips() > 0) {
       <span class="player-card__turn-badge player-card__turn-badge--sm">
         +{{ lastTurnSips() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
+      </span>
+    }
+    @if (lastTurnGiven() > 0) {
+      <span class="player-card__turn-badge player-card__turn-badge--sm player-card__turn-badge--give">
+        +{{ lastTurnGiven() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
       </span>
     }
   </div>
@@ -75,6 +85,11 @@
         >
           {{ sipsGiven() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
         </span>
+        @if (sipsGivenPending() > 0) {
+          <span class="player-card__sip-badge player-card__sip-badge--give-pending">
+            {{ sipsGivenPending() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
+          </span>
+        }
       </div>
     </div>
 
@@ -87,11 +102,18 @@
           </div>
         }
       </div>
-      @if (lastTurnSips() > 0) {
+      @if (lastTurnSips() > 0 || lastTurnGiven() > 0) {
         <div class="player-card__turn-sips">
-          <span class="player-card__turn-badge">
-            +{{ lastTurnSips() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
-          </span>
+          @if (lastTurnSips() > 0) {
+            <span class="player-card__turn-badge">
+              +{{ lastTurnSips() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
+            </span>
+          }
+          @if (lastTurnGiven() > 0) {
+            <span class="player-card__turn-badge player-card__turn-badge--give">
+              +{{ lastTurnGiven() }} <fa-icon [icon]="['fas', 'wine-glass']"></fa-icon>
+            </span>
+          }
         </div>
       }
     </div>

--- a/src/app/_components/players/player-card/player-card.component.scss
+++ b/src/app/_components/players/player-card/player-card.component.scss
@@ -117,12 +117,67 @@
   animation: sip-bounce-anim var(--animation-normal) var(--ease-bounce);
 }
 
+.sip-shake {
+  animation: sip-shake-anim 400ms var(--ease-default);
+}
+
+// Severity-based sip counter colors
+.player-card__sip-badge--drink[data-severity='medium'] {
+  background: rgba(239, 68, 68, 0.25);
+  color: #dc2626;
+}
+.player-card__sip-badge--drink[data-severity='high'] {
+  background: rgba(239, 68, 68, 0.4);
+  color: #b91c1c;
+  font-weight: var(--font-weight-bold);
+}
+
 @keyframes sip-bounce-anim {
   0% {
     transform: scale(1);
   }
   40% {
     transform: scale(1.3);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes sip-shake-anim {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-3px);
+  }
+  80% {
+    transform: translateX(3px);
+  }
+}
+
+// === Match Highlight (Phase 2 card match) ===
+.player-card--match {
+  animation: match-pulse 600ms var(--ease-bounce);
+  border-color: var(--color-accent-gold);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--color-accent-gold) 50%, transparent);
+}
+
+@keyframes match-pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 transparent;
+  }
+  50% {
+    transform: scale(1.03);
+    box-shadow: 0 0 24px color-mix(in srgb, var(--color-accent-gold) 60%, transparent);
   }
   100% {
     transform: scale(1);
@@ -290,8 +345,13 @@
     animation: none;
     box-shadow: 0 0 12px color-mix(in srgb, var(--color-accent-primary) 50%, transparent);
   }
-  .sip-bounce {
+  .sip-bounce,
+  .sip-shake {
     animation: none;
+  }
+  .player-card--match {
+    animation: none;
+    box-shadow: 0 0 12px color-mix(in srgb, var(--color-accent-gold) 50%, transparent);
   }
   .fan-card {
     &:nth-child(1),

--- a/src/app/_components/players/player-card/player-card.component.scss
+++ b/src/app/_components/players/player-card/player-card.component.scss
@@ -111,6 +111,25 @@
     background: var(--color-give-bg);
     color: var(--color-give);
   }
+
+  // Secondary "pending" give badge — outline variant so the solid one keeps the
+  // historical total while this one highlights sips still to dispatch.
+  &--give-pending {
+    background: transparent;
+    color: var(--color-give);
+    border: 1px dashed var(--color-give);
+    animation: sip-pulse-pending 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes sip-pulse-pending {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
 }
 
 .sip-bounce {
@@ -246,6 +265,14 @@
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
   animation: fadeSlideIn var(--animation-normal) var(--ease-default);
+
+  // Give variant: bright pink/magenta — distinct from the green cumulative badge
+  // and from the amber drink per-draw, with enough contrast on the dark-blue card.
+  &--give {
+    background: rgba(236, 72, 153, 0.2);
+    color: #f472b6;
+    margin-left: 4px;
+  }
 }
 
 @keyframes fadeSlideIn {

--- a/src/app/_components/players/player-card/player-card.component.scss
+++ b/src/app/_components/players/player-card/player-card.component.scss
@@ -266,11 +266,12 @@
   font-weight: var(--font-weight-semibold);
   animation: fadeSlideIn var(--animation-normal) var(--ease-default);
 
-  // Give variant: bright pink/magenta — distinct from the green cumulative badge
-  // and from the amber drink per-draw, with enough contrast on the dark-blue card.
+  // Give variant: pink/magenta — distinct from the cumulative green badge and
+  // from the amber drink per-draw. Uses design tokens so light/dark themes
+  // each pick the hue that meets contrast against their card surface.
   &--give {
-    background: rgba(236, 72, 153, 0.2);
-    color: #f472b6;
+    background: var(--color-give-event-bg);
+    color: var(--color-give-event);
     margin-left: 4px;
   }
 }

--- a/src/app/_components/players/player-card/player-card.component.spec.ts
+++ b/src/app/_components/players/player-card/player-card.component.spec.ts
@@ -5,15 +5,21 @@ import { Subject } from 'rxjs';
 import { PlayerCardComponent } from './player-card.component';
 import { GameService } from '../../../services/game/game.service';
 import { PlayerHelperService } from '../../../_shared/_helpers/player.helper';
+import { AuthService } from '../../../services/auth/auth.service';
 import { PlayerModel } from '../../../_shared/_models/player.model';
 import { Game } from '../../../_shared/_models/game.model';
-import { createMockGameService, createMockPlayerHelperService } from '../../../testing/test-helpers';
+import {
+  createMockAuthService,
+  createMockGameService,
+  createMockPlayerHelperService,
+} from '../../../testing/test-helpers';
 
 describe('PlayerCardComponent', () => {
   let component: PlayerCardComponent;
   let fixture: ComponentFixture<PlayerCardComponent>;
   let mockGameService: ReturnType<typeof createMockGameService>;
   let mockPlayerHelperService: jasmine.SpyObj<PlayerHelperService>;
+  let mockAuthService: ReturnType<typeof createMockAuthService>;
   let sipGiveModalSubject: Subject<PlayerModel>;
 
   const mockPlayer: PlayerModel = {
@@ -50,6 +56,11 @@ describe('PlayerCardComponent', () => {
     sipGiveModalSubject = new Subject<PlayerModel>();
     mockGameService = createMockGameService();
     mockPlayerHelperService = createMockPlayerHelperService();
+    mockAuthService = createMockAuthService();
+    // Default to logged-in non-anonymous so existing tests that exercise the
+    // give-modal / summary code paths aren't blocked by the anonymous guards.
+    mockAuthService.isLoggedIn.set(true);
+    mockAuthService.isAnonymous.set(false);
 
     Object.defineProperty(mockGameService, 'openSipGiveModalEvent$', {
       get: () => sipGiveModalSubject.asObservable(),
@@ -63,6 +74,7 @@ describe('PlayerCardComponent', () => {
       providers: [
         { provide: GameService, useValue: mockGameService },
         { provide: PlayerHelperService, useValue: mockPlayerHelperService },
+        { provide: AuthService, useValue: mockAuthService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/src/app/_components/players/player-card/player-card.component.ts
+++ b/src/app/_components/players/player-card/player-card.component.ts
@@ -118,6 +118,9 @@ export class PlayerCardComponent implements OnInit {
 
   private sipInitialized = false;
   private prevSipCount = 0;
+  private bounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private shakeTimer: ReturnType<typeof setTimeout> | null = null;
+  private matchTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     // Trigger bounce/shake animation when sip count changes (skip initial)
@@ -133,15 +136,19 @@ export class PlayerCardComponent implements OnInit {
       this.prevSipCount = current;
 
       // Always bounce
+      if (this.bounceTimer) {
+        clearTimeout(this.bounceTimer);
+      }
       this.sipBounce.set(true);
-      const bounceTimer = setTimeout(() => this.sipBounce.set(false), 300);
-      this.destroyRef.onDestroy(() => clearTimeout(bounceTimer));
+      this.bounceTimer = setTimeout(() => this.sipBounce.set(false), 300);
 
       // Shake on large jumps (3+ sips at once)
       if (delta >= 3) {
+        if (this.shakeTimer) {
+          clearTimeout(this.shakeTimer);
+        }
         this.sipShake.set(true);
-        const shakeTimer = setTimeout(() => this.sipShake.set(false), 400);
-        this.destroyRef.onDestroy(() => clearTimeout(shakeTimer));
+        this.shakeTimer = setTimeout(() => this.sipShake.set(false), 400);
       }
     });
 
@@ -154,9 +161,23 @@ export class PlayerCardComponent implements OnInit {
       }
       const hasMatch = this.player.cards.some((c) => c?.value === matchValue);
       if (hasMatch) {
+        if (this.matchTimer) {
+          clearTimeout(this.matchTimer);
+        }
         this.matchHighlight.set(true);
-        const timer = setTimeout(() => this.matchHighlight.set(false), 2000);
-        this.destroyRef.onDestroy(() => clearTimeout(timer));
+        this.matchTimer = setTimeout(() => this.matchHighlight.set(false), 2000);
+      }
+    });
+
+    this.destroyRef.onDestroy(() => {
+      if (this.bounceTimer) {
+        clearTimeout(this.bounceTimer);
+      }
+      if (this.shakeTimer) {
+        clearTimeout(this.shakeTimer);
+      }
+      if (this.matchTimer) {
+        clearTimeout(this.matchTimer);
       }
     });
   }

--- a/src/app/_components/players/player-card/player-card.component.ts
+++ b/src/app/_components/players/player-card/player-card.component.ts
@@ -188,6 +188,15 @@ export class PlayerCardComponent implements OnInit {
         this.openPlayerGivenSipsModal(player);
       }
     });
+
+    // On component mount (incl. after page refresh), if this player has pending
+    // givenSips to distribute, auto-open the modal so the user isn't stuck.
+    // Deferred to next tick so @ViewChild (playerGivenSipsModal) is resolved.
+    setTimeout(() => {
+      if (this.player && this.playerSrv.getTotalGivenSips(this.player) > 0) {
+        this.openPlayerGivenSipsModal(this.player);
+      }
+    }, 0);
   }
 
   openPlayerGivenSipsModal(player: PlayerModel): void {

--- a/src/app/_components/players/player-card/player-card.component.ts
+++ b/src/app/_components/players/player-card/player-card.component.ts
@@ -76,14 +76,24 @@ export class PlayerCardComponent implements OnInit {
     return this.player ? this.playerSrv.getSipCnt(this.gameSrv.game(), this.player, true) : 0;
   });
 
-  /** Sips to drink (absolute) */
+  /** Sips to drink (absolute) — in Phase 2, shows only Phase 2 sips */
   readonly sipsDrunk = computed(() => {
+    const game = this.gameSrv.game();
+    if (game.phase === 2 && this.player?.sips) {
+      const total = this.player.sips['drunk'] ?? 0;
+      const phase1 = this.player.sips['phase1Drunk'] ?? 0;
+      return total - phase1;
+    }
     const count = this.sipCount();
     return count < 0 ? Math.abs(count) : 0;
   });
 
-  /** Sips to give */
+  /** Sips to give — in Phase 2, shows only Phase 2 sips */
   readonly sipsGiven = computed(() => {
+    const game = this.gameSrv.game();
+    if (game.phase === 2 && this.player?.sips) {
+      return this.player.sips['given'] ?? 0;
+    }
     const count = this.sipCount();
     return count > 0 ? count : 0;
   });

--- a/src/app/_components/players/player-card/player-card.component.ts
+++ b/src/app/_components/players/player-card/player-card.component.ts
@@ -19,6 +19,7 @@ import { PlayerModel } from '../../../_shared/_models/player.model';
 import { GameService } from '../../../services/game/game.service';
 import { PlayerGivenSipsSelectionComponent } from '../player-given-sips-selection/player-given-sips-selection.component';
 import { PlayingCardComponent } from '../../../_shared/_components/playing-card/playing-card.component';
+import { AuthService } from '../../../services/auth/auth.service';
 
 @Component({
   selector: 'app-player-card',
@@ -31,7 +32,8 @@ import { PlayingCardComponent } from '../../../_shared/_components/playing-card/
 export class PlayerCardComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly playerSrv = inject(PlayerHelperService);
-  private readonly gameSrv = inject(GameService);
+  readonly gameSrv = inject(GameService);
+  private readonly authService = inject(AuthService);
 
   @ViewChild(PlayerGivenSipsSelectionComponent)
   private playerGivenSipsModal: PlayerGivenSipsSelectionComponent | undefined;
@@ -76,7 +78,8 @@ export class PlayerCardComponent implements OnInit {
     return this.player ? this.playerSrv.getSipCnt(this.gameSrv.game(), this.player, true) : 0;
   });
 
-  /** Sips to drink (absolute) — in Phase 2, shows only Phase 2 sips */
+  /** Cumulative sips drunk in Phase 2 (mirrors Phase 1 red-badge semantics).
+   * Per-event amount is carried by the orange `lastTurnSips` badge instead. */
   readonly sipsDrunk = computed(() => {
     const game = this.gameSrv.game();
     if (game.phase === 2 && this.player?.sips) {
@@ -88,7 +91,8 @@ export class PlayerCardComponent implements OnInit {
     return count < 0 ? Math.abs(count) : 0;
   });
 
-  /** Sips to give — in Phase 2, shows only Phase 2 sips */
+  /** Cumulative sips to give in Phase 2 (historical). Pending still-to-dispatch is
+   * surfaced separately via `sipsGivenPending`. */
   readonly sipsGiven = computed(() => {
     const game = this.gameSrv.game();
     if (game.phase === 2 && this.player?.sips) {
@@ -96,6 +100,16 @@ export class PlayerCardComponent implements OnInit {
     }
     const count = this.sipCount();
     return count > 0 ? count : 0;
+  });
+
+  /** Pending sips not yet distributed via the give modal. Only meaningful when summary
+   * mode is active (otherwise `card.givenSips` is never assigned, so this stays 0). */
+  readonly sipsGivenPending = computed(() => {
+    const game = this.gameSrv.game();
+    if (game.phase === 2 && this.player) {
+      return this.playerSrv.getTotalGivenSips(this.player);
+    }
+    return 0;
   });
 
   /** Sip severity for color-coded counter (T4) */
@@ -110,10 +124,19 @@ export class PlayerCardComponent implements OnInit {
     return 'low';
   });
 
-  /** Per-turn sip indicator for Phase 1 - resets when active player changes */
+  /** Per-turn drink indicator (Phase 1 & Phase 2 drink events). Resets when
+   * the active player changes (Phase 1) or next card is drawn (Phase 2). */
   readonly lastTurnSips = computed(() => {
     this.gameSrv.lastTurnSips();
     return this.player ? this.gameSrv.getLastTurnSipsForPlayer(this.player.id) : 0;
+  });
+
+  /** Per-turn give indicator (Phase 2 give events only). Works with or without
+   * summary mode — shows how many sips this player must give this draw. Clears
+   * on next card draw. */
+  readonly lastTurnGiven = computed(() => {
+    this.gameSrv.lastTurnGiven();
+    return this.player ? this.gameSrv.getLastTurnGivenForPlayer(this.player.id) : 0;
   });
 
   private sipInitialized = false;
@@ -204,8 +227,13 @@ export class PlayerCardComponent implements OnInit {
       return;
     }
 
-    const hasSipsToGive = this.sipsGiven() > 0 && this.playerSrv.getTotalGivenSips(player) > 0;
-    if (hasSipsToGive) {
+    // Anonymous / logged-out users have no summary UI and must not receive give modals
+    // (game state might still carry summary=true from a previous logged-in session).
+    if (!this.authService.isLoggedIn() || this.authService.isAnonymous()) {
+      return;
+    }
+
+    if (this.playerSrv.getTotalGivenSips(player) > 0) {
       this.playerGivenSipsModal?.openModal(player);
     }
   }

--- a/src/app/_components/players/player-card/player-card.component.ts
+++ b/src/app/_components/players/player-card/player-card.component.ts
@@ -48,6 +48,10 @@ export class PlayerCardComponent implements OnInit {
 
   /** Bounce animation trigger */
   readonly sipBounce = signal(false);
+  /** Shake animation for large sip jumps */
+  readonly sipShake = signal(false);
+  /** Match highlight when Phase 2 card matches player's hand */
+  readonly matchHighlight = signal(false);
 
   /** Player initials for avatar fallback */
   readonly initials = computed(() => {
@@ -84,6 +88,18 @@ export class PlayerCardComponent implements OnInit {
     return count > 0 ? count : 0;
   });
 
+  /** Sip severity for color-coded counter (T4) */
+  readonly sipSeverity = computed<'low' | 'medium' | 'high'>(() => {
+    const abs = this.sipCountAbsolute();
+    if (abs >= 13) {
+      return 'high';
+    }
+    if (abs >= 6) {
+      return 'medium';
+    }
+    return 'low';
+  });
+
   /** Per-turn sip indicator for Phase 1 - resets when active player changes */
   readonly lastTurnSips = computed(() => {
     this.gameSrv.lastTurnSips();
@@ -91,19 +107,47 @@ export class PlayerCardComponent implements OnInit {
   });
 
   private sipInitialized = false;
+  private prevSipCount = 0;
 
   constructor() {
-    // Trigger bounce animation when sip count changes (skip initial)
+    // Trigger bounce/shake animation when sip count changes (skip initial)
     effect(() => {
-      this.sipCountAbsolute();
+      const current = this.sipCountAbsolute();
       if (!this.sipInitialized) {
         this.sipInitialized = true;
+        this.prevSipCount = current;
         return;
       }
+
+      const delta = Math.abs(current - this.prevSipCount);
+      this.prevSipCount = current;
+
+      // Always bounce
       this.sipBounce.set(true);
-      const timer = setTimeout(() => this.sipBounce.set(false), 300);
-      // Cleanup on destroy
-      this.destroyRef.onDestroy(() => clearTimeout(timer));
+      const bounceTimer = setTimeout(() => this.sipBounce.set(false), 300);
+      this.destroyRef.onDestroy(() => clearTimeout(bounceTimer));
+
+      // Shake on large jumps (3+ sips at once)
+      if (delta >= 3) {
+        this.sipShake.set(true);
+        const shakeTimer = setTimeout(() => this.sipShake.set(false), 400);
+        this.destroyRef.onDestroy(() => clearTimeout(shakeTimer));
+      }
+    });
+
+    // Match highlight when Phase 2 card matches (T6)
+    effect(() => {
+      const matchValue = this.gameSrv.phase2LastCardValue?.();
+      if (!matchValue || !this.player?.cards) {
+        this.matchHighlight.set(false);
+        return;
+      }
+      const hasMatch = this.player.cards.some((c) => c?.value === matchValue);
+      if (hasMatch) {
+        this.matchHighlight.set(true);
+        const timer = setTimeout(() => this.matchHighlight.set(false), 2000);
+        this.destroyRef.onDestroy(() => clearTimeout(timer));
+      }
     });
   }
 

--- a/src/app/_components/players/player-card/player-card.component.ts
+++ b/src/app/_components/players/player-card/player-card.component.ts
@@ -38,6 +38,13 @@ export class PlayerCardComponent implements OnInit {
   @ViewChild(PlayerGivenSipsSelectionComponent)
   private playerGivenSipsModal: PlayerGivenSipsSelectionComponent | undefined;
 
+  /** NOTE on reactivity: `player` is a plain `@Input` (not an `input()` signal), yet
+   * the computeds below read `this.player.sips` / `this.player.cards`. Re-evaluation
+   * relies on `gameSrv.game()` ticking whenever player data changes — which is
+   * always the case because mutations flow through `GameService.updateGame()` which
+   * calls `_game.set(...)`. Any change to `player` identity or contents therefore
+   * happens alongside a game-signal emission. Do not introduce code paths that
+   * mutate `player` without going through `updateGame` or the badges will go stale. */
   @Input() player: PlayerModel = new PlayerModel();
   @Input() isActive = false;
   @Input() hasActivePlayer = false;
@@ -214,6 +221,10 @@ export class PlayerCardComponent implements OnInit {
 
     // On component mount (incl. after page refresh), if this player has pending
     // givenSips to distribute, auto-open the modal so the user isn't stuck.
+    // Anonymous users don't use summary/give flows — skip the timer entirely.
+    if (!this.authService.isLoggedIn() || this.authService.isAnonymous()) {
+      return;
+    }
     // Deferred to next tick so @ViewChild (playerGivenSipsModal) is resolved.
     setTimeout(() => {
       if (this.player && this.playerSrv.getTotalGivenSips(this.player) > 0) {

--- a/src/app/_components/players/player-card/player-card.component.ts
+++ b/src/app/_components/players/player-card/player-card.component.ts
@@ -174,7 +174,7 @@ export class PlayerCardComponent implements OnInit {
       return;
     }
 
-    const hasSipsToGive = this.sipCount() > 0 && this.playerSrv.getTotalGivenSips(player) > 0;
+    const hasSipsToGive = this.sipsGiven() > 0 && this.playerSrv.getTotalGivenSips(player) > 0;
     if (hasSipsToGive) {
       this.playerGivenSipsModal?.openModal(player);
     }

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.html
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.html
@@ -22,32 +22,53 @@
         <span class="sip-modal__remaining-label" [translate]="'Remaining_Sips'"></span>
       </div>
 
+      <!-- Hint: tap-to-give affordance -->
+      @if (sipsToGive > 0) {
+        <p class="sip-modal__hint" [translate]="'Sip_Modal_Hint'"></p>
+      }
+
       <!-- Player avatar grid (quick-tap) -->
       <div class="sip-modal__grid">
         @for (player of players; track player.id) {
-          <div class="sip-modal__player" (click)="increase(player)">
+          <button
+            class="sip-modal__player"
+            type="button"
+            [attr.aria-label]="'+1 ' + player.name"
+            [disabled]="sipsToGive <= 0"
+            (click)="increase(player)"
+          >
             <div class="sip-modal__player-avatar-wrapper">
               <img class="sip-modal__player-avatar" [src]="player.avatarSrc" [alt]="player.name" />
               @if (tempSips[player.id] > 0) {
                 <span class="sip-modal__player-badge">{{ tempSips[player.id] }}</span>
               }
+              @if (sipsToGive > 0) {
+                <span class="sip-modal__player-cue" aria-hidden="true">+1</span>
+              }
             </div>
             <span class="sip-modal__player-name">{{ player.name }}</span>
             <div class="sip-modal__player-controls">
-              <button class="sip-modal__ctrl-btn" type="button" (click)="decrease(player); $event.stopPropagation()">
+              <button
+                class="sip-modal__ctrl-btn"
+                type="button"
+                [attr.aria-label]="'-1 ' + player.name"
+                [disabled]="tempSips[player.id] <= 0"
+                (click)="decrease(player); $event.stopPropagation()"
+              >
                 <fa-icon [icon]="['fas', 'minus']"></fa-icon>
               </button>
-              @if (sipsToGive > 0) {
+              @if (sipsToGive > 1) {
                 <button
                   class="sip-modal__ctrl-btn sip-modal__ctrl-btn--all"
                   type="button"
+                  [attr.aria-label]="'+' + sipsToGive + ' ' + player.name"
                   (click)="increase(player, sipsToGive); $event.stopPropagation()"
                 >
                   +{{ sipsToGive }}
                 </button>
               }
             </div>
-          </div>
+          </button>
         }
       </div>
 

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.html
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.html
@@ -1,42 +1,61 @@
-<div id="playerSipsSelectionModal" class="modal">
-  <div class="modal-content">
-    <span class="input-group-text">
-      <span> <img alt="avatar" class="img-thumbnail" src="{{ givenPlayer.avatarSrc }}" /></span>
-      <span> {{ givenPlayer.name }}</span>
-      <span [translate]="'Label_Give'"> </span>
-      <span> {{ sipsToGive }}</span>
-      <span [translate]="'Remaining_Sips'"> </span>
-    </span>
+@if (modalOpen) {
+  <div class="sip-modal-overlay" (click)="closeModal()">
+    <div class="sip-modal" (click)="$event.stopPropagation()">
+      <!-- Header: who is giving -->
+      <div class="sip-modal__header">
+        <img class="sip-modal__avatar" [src]="givenPlayer.avatarSrc" [alt]="givenPlayer.name" />
+        <div class="sip-modal__title">
+          <span class="sip-modal__name">{{ givenPlayer.name }}</span>
+          <span class="sip-modal__subtitle" [translate]="'Label_Give'"></span>
+        </div>
+      </div>
 
-    <div class="list-group">
-      @for (player of players; track player.id) {
-        <div class="list-group-item">
-          {{ player.name }}
-          <div class="input-group">
-            <div class="d-flex justify-content-center">
-              <input type="number" class="form-control" [value]="tempSips[player.id]" readonly />
-              <button class="btn btn-outline-secondary" type="button" (click)="decrease(player)">
+      <!-- Remaining sips counter -->
+      <div class="sip-modal__remaining" [ngClass]="{ 'sip-modal__remaining--done': sipsToGive === 0 }">
+        <span class="sip-modal__remaining-count">{{ sipsToGive }}</span>
+        <span class="sip-modal__remaining-label" [translate]="'Remaining_Sips'"></span>
+      </div>
+
+      <!-- Player avatar grid (quick-tap) -->
+      <div class="sip-modal__grid">
+        @for (player of players; track player.id) {
+          <div class="sip-modal__player" (click)="increase(player)">
+            <div class="sip-modal__player-avatar-wrapper">
+              <img class="sip-modal__player-avatar" [src]="player.avatarSrc" [alt]="player.name" />
+              @if (tempSips[player.id] > 0) {
+                <span class="sip-modal__player-badge">{{ tempSips[player.id] }}</span>
+              }
+            </div>
+            <span class="sip-modal__player-name">{{ player.name }}</span>
+            <div class="sip-modal__player-controls">
+              <button class="sip-modal__ctrl-btn" type="button" (click)="decrease(player); $event.stopPropagation()">
                 <fa-icon [icon]="['fas', 'minus']"></fa-icon>
               </button>
-              <button class="btn btn-outline-secondary" type="button" (click)="increase(player)">
-                <fa-icon [icon]="['fas', 'plus']"></fa-icon>
-              </button>
               @if (sipsToGive > 0) {
-                <button class="btn btn-outline-secondary" type="button" (click)="increase(player, sipsToGive)">
-                  {{ sipsToGive }}
+                <button
+                  class="sip-modal__ctrl-btn sip-modal__ctrl-btn--all"
+                  type="button"
+                  (click)="increase(player, sipsToGive); $event.stopPropagation()"
+                >
+                  +{{ sipsToGive }}
                 </button>
               }
             </div>
           </div>
-        </div>
-      }
-    </div>
+        }
+      </div>
 
-    <div class="button-container">
-      <button class="btn btn-secondary" (click)="closeModal()">Close</button>
-      <button class="btn btn-success" (click)="save()">Save</button>
+      <!-- Actions -->
+      <div class="sip-modal__actions">
+        <button
+          class="sip-modal__btn sip-modal__btn--cancel"
+          (click)="closeModal()"
+          [translate]="'Button_Cancel'"
+        ></button>
+        <button class="sip-modal__btn sip-modal__btn--confirm" (click)="save()" [translate]="'Button_Confirm'"></button>
+      </div>
     </div>
   </div>
-</div>
+}
 
 <app-toast #assignAllSips [titleMessage]="'Warning'" [bodyMessage]="'Assign_All_Given_Sips'"></app-toast>

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.html
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.html
@@ -1,11 +1,17 @@
 @if (modalOpen) {
   <div class="sip-modal-overlay" (click)="closeModal()">
-    <div class="sip-modal" (click)="$event.stopPropagation()">
+    <div
+      class="sip-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="sip-modal-title"
+      (click)="$event.stopPropagation()"
+    >
       <!-- Header: who is giving -->
       <div class="sip-modal__header">
         <img class="sip-modal__avatar" [src]="givenPlayer.avatarSrc" [alt]="givenPlayer.name" />
         <div class="sip-modal__title">
-          <span class="sip-modal__name">{{ givenPlayer.name }}</span>
+          <span id="sip-modal-title" class="sip-modal__name">{{ givenPlayer.name }}</span>
           <span class="sip-modal__subtitle" [translate]="'Label_Give'"></span>
         </div>
       </div>

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.scss
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.scss
@@ -89,6 +89,16 @@
     margin-top: 2px;
   }
 
+  // Hint text (tap affordance)
+  &__hint {
+    text-align: center;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin: 0 0 var(--space-3);
+    font-style: italic;
+    opacity: 0.8;
+  }
+
   // Player avatar grid
   &__grid {
     display: flex;
@@ -108,10 +118,29 @@
     border-radius: var(--radius-lg);
     transition: background var(--animation-fast) var(--ease-default);
     min-width: 72px;
+    // Reset button defaults
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
 
-    &:active {
+    &:active:not(:disabled) {
       background: color-mix(in srgb, var(--color-accent-primary) 15%, transparent);
       transform: scale(0.95);
+    }
+
+    &:hover:not(:disabled) {
+      background: color-mix(in srgb, var(--color-accent-primary) 8%, transparent);
+
+      .sip-modal__player-cue {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.6;
     }
   }
 
@@ -143,6 +172,29 @@
     align-items: center;
     justify-content: center;
     animation: badge-pop 200ms var(--ease-bounce);
+    z-index: 2;
+  }
+
+  // Subtle "+1" cue overlaid on the avatar to signal tap-to-give affordance
+  &__player-cue {
+    position: absolute;
+    bottom: -6px;
+    left: 50%;
+    transform: translateX(-50%) translateY(4px) scale(0.9);
+    padding: 2px 8px;
+    border-radius: var(--radius-full);
+    background: color-mix(in srgb, var(--color-accent-primary) 90%, transparent);
+    color: #fff;
+    font-size: 0.65rem;
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0.02em;
+    pointer-events: none;
+    opacity: 0.75;
+    transition:
+      opacity var(--animation-fast) var(--ease-default),
+      transform var(--animation-fast) var(--ease-default);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+    animation: cue-pulse 2s ease-in-out infinite;
   }
 
   &__player-name {
@@ -260,6 +312,18 @@
   }
 }
 
+@keyframes cue-pulse {
+  0%,
+  100% {
+    opacity: 0.7;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(-2px) scale(1.05);
+  }
+}
+
 // Toast override for modal context
 .toast {
   position: fixed;
@@ -278,6 +342,9 @@
     animation: none;
   }
   .sip-modal__player-badge {
+    animation: none;
+  }
+  .sip-modal__player-cue {
     animation: none;
   }
 }

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.scss
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.scss
@@ -1,61 +1,283 @@
-.modal {
-  display: none;
+// === Sip Distribution Modal (Glassmorphism) ===
+.sip-modal-overlay {
   position: fixed;
-  padding-top: 100px;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgb(0, 0, 0);
-  background-color: rgba(0, 0, 0, 0.4);
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
   align-items: center;
   justify-content: center;
-  align-content: center;
   z-index: 5000;
+  padding: var(--space-4);
+  animation: overlay-fade-in 200ms ease-out;
 }
 
-.modal-content {
-  background-color: #fefefe;
-  margin: auto;
-  z-index: 6000;
-  padding: 20px;
-  border: 1px solid #888;
-  width: 80%;
+.sip-modal {
+  background: color-mix(in srgb, var(--color-bg-elevated) 85%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
+  border-radius: var(--radius-xl, 16px);
+  padding: var(--space-4);
+  width: 100%;
+  max-width: 380px;
+  max-height: 80vh;
+  overflow-y: auto;
+  animation: modal-slide-up 300ms var(--ease-spring, ease-out);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+  }
+
+  &__avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--radius-full);
+    border: 2px solid var(--color-accent-gold, #d97706);
+    object-fit: cover;
+  }
+
+  &__title {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__name {
+    font-size: var(--font-size-lg, 1.1rem);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-primary);
+  }
+
+  &__subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
+
+  // Remaining sips counter
+  &__remaining {
+    text-align: center;
+    padding: var(--space-2) var(--space-3);
+    margin-bottom: var(--space-3);
+    border-radius: var(--radius-lg);
+    background: color-mix(in srgb, var(--color-accent-primary) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-accent-primary) 20%, transparent);
+    transition: all var(--animation-normal) var(--ease-default);
+
+    &--done {
+      background: rgba(34, 197, 94, 0.1);
+      border-color: rgba(34, 197, 94, 0.2);
+
+      .sip-modal__remaining-count {
+        color: #22c55e;
+      }
+    }
+  }
+
+  &__remaining-count {
+    font-size: 2rem;
+    font-weight: var(--font-weight-bold);
+    color: var(--color-accent-primary, #6366f1);
+    line-height: 1;
+  }
+
+  &__remaining-label {
+    display: block;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin-top: 2px;
+  }
+
+  // Player avatar grid
+  &__grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+  }
+
+  &__player {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-1);
+    cursor: pointer;
+    padding: var(--space-2);
+    border-radius: var(--radius-lg);
+    transition: background var(--animation-fast) var(--ease-default);
+    min-width: 72px;
+
+    &:active {
+      background: color-mix(in srgb, var(--color-accent-primary) 15%, transparent);
+      transform: scale(0.95);
+    }
+  }
+
+  &__player-avatar-wrapper {
+    position: relative;
+  }
+
+  &__player-avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: var(--radius-full);
+    border: 2px solid var(--color-border);
+    object-fit: cover;
+    transition: border-color var(--animation-fast) var(--ease-default);
+  }
+
+  &__player-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    width: 20px;
+    height: 20px;
+    border-radius: var(--radius-full);
+    background: var(--color-accent-primary, #6366f1);
+    color: #fff;
+    font-size: 0.65rem;
+    font-weight: var(--font-weight-bold);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: badge-pop 200ms var(--ease-bounce);
+  }
+
+  &__player-name {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+    text-align: center;
+    max-width: 64px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__player-controls {
+    display: flex;
+    gap: var(--space-1);
+  }
+
+  &__ctrl-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--radius-full);
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-surface);
+    color: var(--color-text-primary);
+    font-size: 0.65rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all var(--animation-fast) var(--ease-default);
+
+    &:active {
+      transform: scale(0.9);
+      background: var(--color-bg-elevated);
+    }
+
+    &--all {
+      width: auto;
+      padding: 0 8px;
+      font-weight: var(--font-weight-bold);
+      background: rgba(99, 102, 241, 0.1);
+      border-color: rgba(99, 102, 241, 0.3);
+      color: var(--color-accent-primary);
+    }
+  }
+
+  // Action buttons
+  &__actions {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  &__btn {
+    flex: 1;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-lg);
+    border: none;
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+    transition: all var(--animation-fast) var(--ease-default);
+
+    &--cancel {
+      background: var(--color-bg-surface);
+      color: var(--color-text-secondary);
+      border: 1px solid var(--color-border);
+
+      &:active {
+        transform: scale(0.97);
+      }
+    }
+
+    &--confirm {
+      background: var(--color-accent-primary);
+      color: #fff;
+
+      &:active {
+        transform: scale(0.97);
+        filter: brightness(0.9);
+      }
+    }
+  }
 }
 
-.close {
-  color: #aaaaaa;
-  float: right;
-  font-size: 28px;
-  font-weight: bold;
+@keyframes overlay-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
-.close:hover,
-.close:focus {
-  color: #000;
-  text-decoration: none;
-  cursor: pointer;
+@keyframes modal-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
-
-.input-group-text span {
-  margin-right: 10px;
+@keyframes badge-pop {
+  0% {
+    transform: scale(0);
+  }
+  70% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
+// Toast override for modal context
 .toast {
   position: fixed;
   top: 35%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 1051; /* Higher than the z-index of the modal */
+  z-index: 6000;
 }
 
-.button-container {
-  display: flex;
-  justify-content: space-between;
-}
-
-.button-container .btn {
-  width: 45%;
+// Reduced motion
+@media (prefers-reduced-motion: reduce) {
+  .sip-modal-overlay {
+    animation: none;
+  }
+  .sip-modal {
+    animation: none;
+  }
+  .sip-modal__player-badge {
+    animation: none;
+  }
 }

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.spec.ts
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.spec.ts
@@ -250,15 +250,14 @@ describe('PlayerGivenSipsSelectionComponent', () => {
     });
   });
 
-  describe('resetSips() method', () => {
+  describe('closeModal() resets sips', () => {
     beforeEach(() => {
-      // Initialize tempSips for players
       component.players.forEach((p) => {
         component.tempSips[p.id] = 0;
       });
     });
 
-    it('should reset all tempSips to 0', () => {
+    it('should reset all tempSips to 0 on close', () => {
       const player1 = component.players[0];
       const player2 = component.players[1];
       const player3 = component.players[2];
@@ -267,16 +266,16 @@ describe('PlayerGivenSipsSelectionComponent', () => {
       component.tempSips[player3.id] = 2;
       component.sipsToGive = 10;
 
-      component.resetSips();
+      component.closeModal();
 
       expect(component.tempSips[player1.id]).toBe(0);
       expect(component.tempSips[player2.id]).toBe(0);
       expect(component.tempSips[player3.id]).toBe(0);
     });
 
-    it('should reset sipsToGive to 0', () => {
+    it('should reset sipsToGive to 0 on close', () => {
       component.sipsToGive = 15;
-      component.resetSips();
+      component.closeModal();
 
       expect(component.sipsToGive).toBe(0);
     });

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.spec.ts
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.spec.ts
@@ -290,13 +290,15 @@ describe('PlayerGivenSipsSelectionComponent', () => {
       });
     });
 
-    it('should hide the modal by setting display to none', () => {
-      const modal = fixture.nativeElement.querySelector('#playerSipsSelectionModal');
-      modal.style.display = 'flex';
+    it('should close the modal (modalOpen flips to false)', () => {
+      // The component uses an Angular `@if (modalOpen)` to mount/unmount the
+      // modal markup instead of toggling display: none on a fixed DOM node, so
+      // we assert the boolean state rather than inspecting computed styles.
+      component.modalOpen = true;
 
       component.closeModal();
 
-      expect(modal.style.display).toBe('none');
+      expect(component.modalOpen).toBeFalse();
     });
 
     it('should reset sips when closing modal', () => {
@@ -314,7 +316,7 @@ describe('PlayerGivenSipsSelectionComponent', () => {
   describe('openModal() method', () => {
     beforeEach(() => {
       fixture.detectChanges();
-      mockPlayerHelperService.getSipCnt.and.returnValue(5);
+      mockPlayerHelperService.getTotalGivenSips.and.returnValue(5);
     });
 
     it('should set givenPlayer to the provided player', () => {
@@ -323,20 +325,23 @@ describe('PlayerGivenSipsSelectionComponent', () => {
       expect(component.givenPlayer).toEqual(testPlayers[0]);
     });
 
-    it('should set sipsToGive by calling playerHelper.getSipCnt', () => {
+    it('should set sipsToGive by calling playerHelper.getTotalGivenSips', () => {
+      // The component reads pending sips from `getTotalGivenSips(player)` (sums
+      // each card's pending givenSips) — not from the older `getSipCnt(game, player)`.
       component.openModal(testPlayers[0]);
 
-      expect(mockPlayerHelperService.getSipCnt).toHaveBeenCalledWith(mockGameService.game(), testPlayers[0]);
+      expect(mockPlayerHelperService.getTotalGivenSips).toHaveBeenCalledWith(testPlayers[0]);
       expect(component.sipsToGive).toBe(5);
     });
 
-    it('should show the modal by setting display to flex', () => {
-      const modal = fixture.nativeElement.querySelector('#playerSipsSelectionModal');
-      modal.style.display = 'none';
+    it('should open the modal (modalOpen flips to true)', () => {
+      // The component uses `@if (modalOpen)` to mount the modal markup; we
+      // assert the boolean state rather than inspecting display: flex/none.
+      component.modalOpen = false;
 
       component.openModal(testPlayers[0]);
 
-      expect(modal.style.display).toBe('flex');
+      expect(component.modalOpen).toBeTrue();
     });
 
     it('should initialize tempSips for all players to 0', () => {
@@ -451,7 +456,7 @@ describe('PlayerGivenSipsSelectionComponent', () => {
   describe('Integration Tests', () => {
     beforeEach(() => {
       fixture.detectChanges();
-      mockPlayerHelperService.getSipCnt.and.returnValue(10);
+      mockPlayerHelperService.getTotalGivenSips.and.returnValue(10);
     });
 
     it('should handle complete workflow: open -> distribute -> save -> close', () => {

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.ts
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.ts
@@ -1,5 +1,6 @@
-import { Component, ElementRef, inject, Input, ViewChild } from '@angular/core';
+import { Component, inject, Input, ViewChild } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
+import { NgClass } from '@angular/common';
 import { FontAwesomeIconsModule } from '../../../font-awesome.module';
 import { ToastComponent } from '../../../_shared/_components/toast/toast.component';
 import { PlayerHelperService } from '../../../_shared/_helpers/player.helper';
@@ -12,10 +13,9 @@ import { GameService } from '../../../services/game/game.service';
   templateUrl: './player-given-sips-selection.component.html',
   styleUrls: ['./player-given-sips-selection.component.scss'],
   standalone: true,
-  imports: [TranslateModule, FontAwesomeIconsModule, ToastComponent],
+  imports: [TranslateModule, NgClass, FontAwesomeIconsModule, ToastComponent],
 })
 export class PlayerGivenSipsSelectionComponent {
-  private readonly elementRef = inject(ElementRef);
   readonly gameSrv = inject(GameService);
   readonly playerHelper = inject(PlayerHelperService);
 
@@ -26,12 +26,13 @@ export class PlayerGivenSipsSelectionComponent {
   tempSips: { [key: string]: number } = {};
   sipsToGive = 0;
   givenPlayer = new PlayerModel();
+  modalOpen = false;
 
   get players(): PlayerModel[] {
     return this.gameSrv.players();
   }
 
-  increase(player: any, sips: number = 0) {
+  increase(player: PlayerModel, sips: number = 0): void {
     if (this.sipsToGive <= 0) {
       return;
     }
@@ -39,28 +40,25 @@ export class PlayerGivenSipsSelectionComponent {
     if (sips > 0) {
       this.tempSips[player.id] += sips;
       this.sipsToGive -= sips;
-      return;
     } else {
       this.tempSips[player.id]++;
       this.sipsToGive--;
     }
   }
 
-  decrease(player: any) {
+  decrease(player: PlayerModel): void {
     if (this.tempSips[player.id] > 0) {
       this.tempSips[player.id]--;
       this.sipsToGive++;
     }
   }
 
-  save() {
+  save(): void {
     if (this.sipsToGive !== 0) {
-      if (this.toastComponent) {
-        this.toastComponent.show();
-      }
+      this.toastComponent?.show();
       return;
     }
-    // Implement your save logic here
+
     this.players.forEach((player) => {
       if (this.tempSips[player.id] > 0) {
         this.gameSrv.addPlayerSip(player, this.tempSips[player.id]);
@@ -78,18 +76,12 @@ export class PlayerGivenSipsSelectionComponent {
     this.closeModal();
   }
 
-  resetSips() {
+  closeModal(): void {
+    this.modalOpen = false;
     for (const key in this.tempSips) {
       this.tempSips[key] = 0;
     }
     this.sipsToGive = 0;
-  }
-
-  closeModal() {
-    const modal = this.elementRef.nativeElement.querySelector('#playerSipsSelectionModal');
-    modal.style.display = 'none';
-
-    this.resetSips();
   }
 
   openModal(player: PlayerModel): void {
@@ -100,7 +92,6 @@ export class PlayerGivenSipsSelectionComponent {
       this.tempSips[p.id] = 0;
     });
 
-    const modal = this.elementRef.nativeElement.querySelector('#playerSipsSelectionModal');
-    modal.style.display = 'flex';
+    this.modalOpen = true;
   }
 }

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.ts
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.ts
@@ -86,7 +86,7 @@ export class PlayerGivenSipsSelectionComponent {
 
   openModal(player: PlayerModel): void {
     this.givenPlayer = player;
-    this.sipsToGive = this.playerHelper.getSipCnt(this.gameSrv.game(), player);
+    this.sipsToGive = this.playerHelper.getTotalGivenSips(player);
 
     this.players.forEach((p) => {
       this.tempSips[p.id] = 0;

--- a/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.ts
+++ b/src/app/_components/players/player-given-sips-selection/player-given-sips-selection.component.ts
@@ -38,6 +38,7 @@ export class PlayerGivenSipsSelectionComponent {
     }
 
     if (sips > 0) {
+      sips = Math.min(sips, this.sipsToGive);
       this.tempSips[player.id] += sips;
       this.sipsToGive -= sips;
     } else {

--- a/src/app/_shared/_components/footer/footer.component.html
+++ b/src/app/_shared/_components/footer/footer.component.html
@@ -231,65 +231,108 @@
       </div>
     }
 
-    <!-- Phase 2: Drinking/Giving Panel -->
+    <!-- Phase 2: Draw Pile + Split Lane -->
     @if (gameSrv.phase() === 2) {
       <div class="prediction-panel prediction-panel--phase2">
-        <div class="d-flex flex-column gap-1">
-          @if (gameSrv.isGameStarted() || gameSrv.isGameFinished()) {
-            <div class="d-flex flex-row justify-content-center gap-1">
-              <div>
-                <span class="prediction-panel__phase2-label" [translate]="'Label_YouDrink'"></span>
-                <div class="d-flex flex-row gap-0">
-                  @for (i of cardSlots; track i) {
-                    <div>
-                      <app-playing-card [card]="gameSrv.drinkingCards()[i]" [leftOverlap]="i !== 0"></app-playing-card>
-                    </div>
-                  }
-                </div>
-              </div>
-              <div>
-                <span class="prediction-panel__phase2-label" [translate]="'Label_YouGive'"></span>
-                <div class="d-flex flex-row gap-0">
-                  @for (i of cardSlots; track i) {
-                    <div>
-                      <app-playing-card [card]="gameSrv.givingCards()[i]" [leftOverlap]="i !== 0"></app-playing-card>
-                    </div>
-                  }
-                </div>
+        @if (gameSrv.isGameStarted() || gameSrv.isGameFinished()) {
+          <div class="draw-layout">
+            <!-- Left lane: drink cards (red) -->
+            <div class="draw-lane draw-lane--drink">
+              <span class="draw-lane__label draw-lane__label--drink"> 🍷 {{ gameSrv.drinkingCards().length }}/6 </span>
+              <div class="draw-lane__cards">
+                @for (card of gameSrv.drinkingCards(); track $index) {
+                  <app-playing-card
+                    [card]="card"
+                    [faceDown]="true"
+                    [flipped]="true"
+                    [glowColor]="'red'"
+                    [leftOverlap]="$index !== 0"
+                  ></app-playing-card>
+                }
               </div>
             </div>
-          }
-          @if (gameSrv.givingCards().length < 6) {
-            <div class="text-center">
-              <button
-                type="button"
-                class="btn btn-secondary ms-2 space-below"
-                (click)="onDisplayCard()"
-                [translate]="
-                  gameSrv.drinkingCards().length <= gameSrv.givingCards().length ? 'Label_YouDrink' : 'Label_YouGive'
-                "
-              ></button>
-            </div>
-          }
-          @if (!gameSrv.isNewGame() && gameSrv.givingCards().length === 6) {
-            <div class="text-center">
-              <button
-                type="button"
-                class="btn btn-secondary ms-2 space-below"
-                (click)="restartGame()"
-                [translate]="'Button_Restart'"
-              ></button>
-              @if (gameSrv.isGameFinished() && gameSrv.isSummaryActivated() && !gameSrv.isSummaryMode()) {
+
+            <!-- Center: draw pile -->
+            <div class="draw-pile">
+              @if (!phase2Complete()) {
                 <button
-                  type="button"
-                  class="btn btn-secondary ms-2 space-below"
-                  (click)="displaySummary()"
-                  [translate]="'Button_Display_Summary'"
-                ></button>
+                  class="draw-pile__btn"
+                  [disabled]="revealingPhase2()"
+                  (click)="onDrawPhase2Card()"
+                  [ngClass]="{
+                    'draw-pile__btn--drink': nextIsDrink(),
+                    'draw-pile__btn--give': !nextIsDrink(),
+                  }"
+                >
+                  <!-- Stacked card backs for depth effect -->
+                  <div class="draw-pile__stack">
+                    @if (cardsRemaining() > 2) {
+                      <div class="draw-pile__card draw-pile__card--3"></div>
+                    }
+                    @if (cardsRemaining() > 1) {
+                      <div class="draw-pile__card draw-pile__card--2"></div>
+                    }
+                    <div class="draw-pile__card draw-pile__card--1">
+                      @if (revealingPhase2() && lastDrawnCard(); as drawn) {
+                        <app-playing-card
+                          [card]="drawn"
+                          [faceDown]="true"
+                          [flipped]="true"
+                          [glowColor]="lastDrawnIsDrink() ? 'red' : 'green'"
+                        ></app-playing-card>
+                      } @else {
+                        <img src="assets/images/cards/svg/blue_back.svg" alt="draw pile" />
+                      }
+                    </div>
+                  </div>
+                  <span
+                    class="draw-pile__sip-badge"
+                    [ngClass]="{
+                      'draw-pile__sip-badge--drink': nextIsDrink(),
+                      'draw-pile__sip-badge--give': !nextIsDrink(),
+                    }"
+                  >
+                    {{ nextSipValue() }}
+                  </span>
+                </button>
+              } @else {
+                <!-- All cards drawn: show actions -->
+                <div class="phase2-actions">
+                  <button
+                    type="button"
+                    class="prediction-btn prediction-btn--start"
+                    (click)="restartGame()"
+                    [translate]="'Button_Restart'"
+                  ></button>
+                  @if (gameSrv.isGameFinished() && gameSrv.isSummaryActivated() && !gameSrv.isSummaryMode()) {
+                    <button
+                      type="button"
+                      class="prediction-btn prediction-btn--start"
+                      (click)="displaySummary()"
+                      [translate]="'Button_Display_Summary'"
+                    ></button>
+                  }
+                </div>
               }
             </div>
-          }
-        </div>
+
+            <!-- Right lane: give cards (green) -->
+            <div class="draw-lane draw-lane--give">
+              <span class="draw-lane__label draw-lane__label--give"> 🫳 {{ gameSrv.givingCards().length }}/6 </span>
+              <div class="draw-lane__cards">
+                @for (card of gameSrv.givingCards(); track $index) {
+                  <app-playing-card
+                    [card]="card"
+                    [faceDown]="true"
+                    [flipped]="true"
+                    [glowColor]="'green'"
+                    [leftOverlap]="$index !== 0"
+                  ></app-playing-card>
+                }
+              </div>
+            </div>
+          </div>
+        }
       </div>
     }
 

--- a/src/app/_shared/_components/footer/footer.component.html
+++ b/src/app/_shared/_components/footer/footer.component.html
@@ -3,7 +3,7 @@
     <!-- Phase 1: Prediction Panel -->
     @if (gameSrv.isGameStarted() && ([1, 2, 3, 4].includes(gameSrv.turn()) || isAnimationLocked())) {
       <div class="prediction-panel" [ngClass]="{ 'prediction-panel--animating': isAnimationLocked() }">
-        @if (gameSrv.activePlayer(); as activePlayer) {
+        @if (displayPlayer(); as activePlayer) {
           <div class="prediction-panel__player prediction-panel__player--desktop">
             <img
               class="prediction-panel__avatar"
@@ -94,6 +94,7 @@
             </div>
           }
           @if (displayTurn === 3) {
+            @let inOutRefCards = displayPlayer()?.cards?.slice(0, 2) ?? [];
             <div class="prediction-panel__choices-row">
               <button
                 [attr.aria-label]="'game.turn3.in' | translate"
@@ -105,7 +106,7 @@
                 [disabled]="isAnimationLocked()"
                 (click)="inOut('in')"
               >
-                @for (card of gameSrv.activePlayer()?.cards; track $index; let i = $index) {
+                @for (card of inOutRefCards; track $index; let i = $index) {
                   <div class="inout-card-wrapper">
                     <app-playing-card [card]="card"></app-playing-card>
                     @if (i === 0) {
@@ -127,7 +128,7 @@
                 [disabled]="isAnimationLocked()"
                 (click)="inOut('out')"
               >
-                @for (card of gameSrv.activePlayer()?.cards; track $index; let i = $index) {
+                @for (card of inOutRefCards; track $index; let i = $index) {
                   <div class="inout-card-wrapper">
                     @if (i === 0) {
                       <span class="inout-caret"><fa-icon [icon]="['fas', 'caret-left']"></fa-icon></span>
@@ -231,8 +232,8 @@
       </div>
     }
 
-    <!-- Phase 2: Draw Pile + Split Lane -->
-    @if (gameSrv.phase() === 2) {
+    <!-- Phase 2: Draw Pile + Split Lane (hidden while a Phase 1 animation is still running) -->
+    @if (gameSrv.phase() === 2 && !isAnimationLocked()) {
       <div class="prediction-panel prediction-panel--phase2">
         @if (gameSrv.isGameStarted() || gameSrv.isGameFinished()) {
           <div class="draw-layout">

--- a/src/app/_shared/_components/footer/footer.component.html
+++ b/src/app/_shared/_components/footer/footer.component.html
@@ -232,9 +232,10 @@
       </div>
     }
 
-    <!-- Phase 2: Draw Pile + Split Lane (hidden while a Phase 1 animation is still running) -->
-    @if (gameSrv.phase() === 2 && !isAnimationLocked()) {
-      <div class="prediction-panel prediction-panel--phase2">
+    <!-- Phase 2: Draw Pile + Split Lane (visually hidden while a Phase 1 animation is
+         still running so the draw pile state is preserved across the transition) -->
+    @if (gameSrv.phase() === 2) {
+      <div class="prediction-panel prediction-panel--phase2" [class.prediction-panel--locked]="isAnimationLocked()">
         @if (gameSrv.isGameStarted() || gameSrv.isGameFinished()) {
           <div class="draw-layout">
             <!-- Left lane: drink cards (red) -->

--- a/src/app/_shared/_components/footer/footer.component.scss
+++ b/src/app/_shared/_components/footer/footer.component.scss
@@ -30,6 +30,14 @@
   }
 }
 
+// Hide the Phase 2 panel visually while a Phase 1 animation is still running,
+// but keep it in the DOM so the draw pile / lane counts don't unmount-remount
+// on every transition (preserves pile-count animation state).
+.prediction-panel--locked {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .prediction-panel__player {
   display: flex;
   align-items: center;

--- a/src/app/_shared/_components/footer/footer.component.scss
+++ b/src/app/_shared/_components/footer/footer.component.scss
@@ -648,7 +648,8 @@
   .card-reveal__flip,
   .stepper__icon,
   .stepper__label,
-  .stepper__line {
+  .stepper__line,
+  .draw-pile__sip-badge {
     transition-duration: 0.01ms !important;
     animation-duration: 0.01ms !important;
   }

--- a/src/app/_shared/_components/footer/footer.component.scss
+++ b/src/app/_shared/_components/footer/footer.component.scss
@@ -278,6 +278,193 @@
   margin-bottom: 10px;
 }
 
+// === Phase 2: Draw Pile + Split Lane ===
+.draw-layout {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+  width: 100%;
+
+  @media (max-width: 767px) {
+    gap: var(--space-1);
+  }
+}
+
+.draw-lane {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  flex: 1;
+  min-width: 0;
+
+  &__label {
+    font-size: 0.7rem;
+    font-weight: var(--font-weight-semibold);
+    white-space: nowrap;
+
+    &--drink {
+      color: #ef4444;
+    }
+    &--give {
+      color: #22c55e;
+    }
+  }
+
+  &__cards {
+    display: flex;
+    justify-content: center;
+    min-height: 55px;
+
+    // Smaller cards in lanes
+    ::ng-deep .card-container {
+      width: 36px;
+      min-height: 50px;
+
+      @media (min-width: 768px) {
+        width: 50px;
+        min-height: 70px;
+      }
+    }
+    ::ng-deep .card-container.left-overlap {
+      margin-left: -18px;
+      @media (min-width: 768px) {
+        margin-left: -25px;
+      }
+    }
+  }
+}
+
+.draw-pile {
+  flex-shrink: 0;
+
+  &__btn {
+    position: relative;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    transition: transform var(--animation-fast) var(--ease-spring);
+
+    &:hover:not(:disabled) {
+      transform: scale(1.05);
+    }
+    &:active:not(:disabled) {
+      transform: scale(0.95);
+    }
+    &:disabled {
+      cursor: default;
+    }
+
+    // Pulsing border based on next card type
+    &--drink {
+      .draw-pile__card--1 {
+        box-shadow: 0 0 12px rgba(239, 68, 68, 0.4);
+      }
+    }
+    &--give {
+      .draw-pile__card--1 {
+        box-shadow: 0 0 12px rgba(34, 197, 94, 0.4);
+      }
+    }
+  }
+
+  &__stack {
+    position: relative;
+    width: 50px;
+    height: 70px;
+
+    @media (min-width: 768px) {
+      width: 65px;
+      height: 91px;
+    }
+  }
+
+  &__card {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    border-radius: var(--radius-sm, 3px);
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border-radius: var(--radius-sm, 3px);
+    }
+
+    ::ng-deep .card-container {
+      width: 100% !important;
+      min-height: 100% !important;
+    }
+
+    &--3 {
+      top: -4px;
+      left: 2px;
+      background: var(--color-bg-surface);
+      border: 1px solid var(--color-border);
+      opacity: 0.5;
+    }
+    &--2 {
+      top: -2px;
+      left: 1px;
+      background: var(--color-bg-surface);
+      border: 1px solid var(--color-border);
+      opacity: 0.7;
+    }
+    &--1 {
+      top: 0;
+      left: 0;
+      border-radius: var(--radius-sm, 3px);
+    }
+  }
+
+  &__sip-badge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 22px;
+    height: 22px;
+    border-radius: var(--radius-full);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: var(--font-weight-bold);
+    color: #fff;
+    z-index: 2;
+    animation: sip-pulse 1.5s ease-in-out infinite;
+
+    &--drink {
+      background: #ef4444;
+    }
+    &--give {
+      background: #22c55e;
+    }
+  }
+}
+
+@keyframes sip-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+}
+
+.phase2-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
 // === Card flip 3D reveal ===
 .card-reveal {
   display: flex;

--- a/src/app/_shared/_components/footer/footer.component.scss
+++ b/src/app/_shared/_components/footer/footer.component.scss
@@ -22,6 +22,9 @@
 
 .prediction-panel--phase2 {
   flex-direction: column;
+  // Cards stacked in lanes can extend past the lane's flex share on narrow viewports;
+  // clip here so they stay inside the rounded band instead of bleeding out the sides.
+  overflow: hidden;
   @media (min-width: 768px) {
     flex-direction: column;
   }
@@ -317,6 +320,7 @@
     display: flex;
     justify-content: center;
     min-height: 55px;
+    max-width: 100%;
 
     // Smaller cards in lanes
     ::ng-deep .card-container {
@@ -463,6 +467,14 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) 0;
+
+  // Smaller action buttons here so the flanking card lanes keep usable width.
+  .prediction-btn--start {
+    min-width: 0;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--font-size-sm);
+    white-space: nowrap;
+  }
 }
 
 // === Card flip 3D reveal ===

--- a/src/app/_shared/_components/footer/footer.component.scss
+++ b/src/app/_shared/_components/footer/footer.component.scss
@@ -30,12 +30,15 @@
   }
 }
 
-// Hide the Phase 2 panel visually while a Phase 1 animation is still running,
-// but keep it in the DOM so the draw pile / lane counts don't unmount-remount
-// on every transition (preserves pile-count animation state).
+// Hide the Phase 2 panel while a Phase 1 animation is still running, but keep
+// it in the DOM so the draw pile / lane counts don't unmount-remount on every
+// transition (Angular preserves component state through `display: none`).
+// `display: none` is required (not `visibility: hidden`) — on mobile the Phase 1
+// panel is `position: fixed` and Phase 2 is `position: static`, so a hidden but
+// layout-occupying Phase 2 created a brief visual overlap during the last Turn 4
+// animation (~900 ms transition window).
 .prediction-panel--locked {
-  visibility: hidden;
-  pointer-events: none;
+  display: none;
 }
 
 .prediction-panel__player {

--- a/src/app/_shared/_components/footer/footer.component.spec.ts
+++ b/src/app/_shared/_components/footer/footer.component.spec.ts
@@ -136,52 +136,71 @@ describe('FooterComponent', () => {
     });
   });
 
+  // chooseColor / plusOrMinus / inOut / chooseSuit go through the animatedChoice
+  // pipeline (Story 15.3), which defers the actual setChoiceAndPickCard call
+  // behind a setTimeout so tests must advance fake time to observe the spy call.
   describe('chooseColor', () => {
-    it('should call setChoiceAndPickCard with Color enum and selected color', () => {
+    it('should call setChoiceAndPickCard with Color enum and selected color', fakeAsync(() => {
       component.chooseColor('red');
+      tick(250);
       expect(mockGameService.setChoiceAndPickCard).toHaveBeenCalledWith(DrinkChoiceEnum.Color, 'red');
-    });
+      tick(2000); // drain remaining animation timers
+    }));
 
-    it('should call setChoiceAndPickCard with black color', () => {
+    it('should call setChoiceAndPickCard with black color', fakeAsync(() => {
       component.chooseColor('black');
+      tick(250);
       expect(mockGameService.setChoiceAndPickCard).toHaveBeenCalledWith(DrinkChoiceEnum.Color, 'black');
-    });
+      tick(2000);
+    }));
   });
 
   describe('plusOrMinus', () => {
-    it('should call setChoiceAndPickCard with PlusOrMinus enum', () => {
+    it('should call setChoiceAndPickCard with PlusOrMinus enum', fakeAsync(() => {
       component.plusOrMinus('plus');
+      tick(250);
       expect(mockGameService.setChoiceAndPickCard).toHaveBeenCalledWith(DrinkChoiceEnum.PlusOrMinus, 'plus');
-    });
+      tick(2000);
+    }));
 
-    it('should call setChoiceAndPickCard with minus selection', () => {
+    it('should call setChoiceAndPickCard with minus selection', fakeAsync(() => {
       component.plusOrMinus('minus');
+      tick(250);
       expect(mockGameService.setChoiceAndPickCard).toHaveBeenCalledWith(DrinkChoiceEnum.PlusOrMinus, 'minus');
-    });
+      tick(2000);
+    }));
   });
 
   describe('inOut', () => {
-    it('should call setChoiceAndPickCard with InAndOut enum', () => {
+    it('should call setChoiceAndPickCard with InAndOut enum', fakeAsync(() => {
       component.inOut('in');
+      tick(250);
       expect(mockGameService.setChoiceAndPickCard).toHaveBeenCalledWith(DrinkChoiceEnum.InAndOut, 'in');
-    });
+      tick(2000);
+    }));
 
-    it('should call setChoiceAndPickCard with out selection', () => {
+    it('should call setChoiceAndPickCard with out selection', fakeAsync(() => {
       component.inOut('out');
+      tick(250);
       expect(mockGameService.setChoiceAndPickCard).toHaveBeenCalledWith(DrinkChoiceEnum.InAndOut, 'out');
-    });
+      tick(2000);
+    }));
   });
 
   describe('chooseSuit', () => {
-    it('should call setChoiceAndPickCard with Suit enum', () => {
+    it('should call setChoiceAndPickCard with Suit enum', fakeAsync(() => {
       component.chooseSuit('hearts');
+      tick(250);
       expect(mockGameService.setChoiceAndPickCard).toHaveBeenCalledWith(DrinkChoiceEnum.Suit, 'hearts');
-    });
+      tick(2000);
+    }));
 
-    it('should call setChoiceAndPickCard with spades', () => {
+    it('should call setChoiceAndPickCard with spades', fakeAsync(() => {
       component.chooseSuit('spades');
+      tick(250);
       expect(mockGameService.setChoiceAndPickCard).toHaveBeenCalledWith(DrinkChoiceEnum.Suit, 'spades');
-    });
+      tick(2000);
+    }));
   });
 
   describe('hasPlayers', () => {
@@ -445,7 +464,15 @@ describe('FooterComponent', () => {
     }
 
     it('should return the first card of the active player when cards exist', () => {
-      const card: CardType = { value: '4', suit: 'hearts', icon: null, sips: 0, selected: false, img: 'assets/images/cards/svg/4_of_hearts.svg', givenSips: undefined };
+      const card: CardType = {
+        value: '4',
+        suit: 'hearts',
+        icon: null,
+        sips: 0,
+        selected: false,
+        img: 'assets/images/cards/svg/4_of_hearts.svg',
+        givenSips: undefined,
+      };
       const playerWithCard: PlayerModel = { ...mockPlayer, cards: [card] };
       setActivePlayer(playerWithCard);
 

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -74,6 +74,31 @@ export class FooterComponent implements OnDestroy {
   /** Active timeout IDs for animation cleanup on destroy */
   private readonly _animationTimers: ReturnType<typeof setTimeout>[] = [];
 
+  // === Phase 2 draw pile state ===
+  /** Whether a Phase 2 card flip is in progress */
+  readonly revealingPhase2 = signal(false);
+  /** The last drawn Phase 2 card (shown in draw area during flip animation) */
+  readonly lastDrawnCard = signal<CardType | null>(null);
+  /** Whether the last drawn card was a drink card */
+  readonly lastDrawnIsDrink = signal(true);
+
+  /** Whether the next draw is a drink card (even total = drink, odd = give) */
+  readonly nextIsDrink = computed(() => {
+    const total = this.gameSrv.drinkingCards().length + this.gameSrv.givingCards().length;
+    return total % 2 === 0;
+  });
+
+  /** Number of sips for the next card */
+  readonly nextSipValue = computed(() => this.gameSrv.getSipsNumber());
+
+  /** Whether all 12 Phase 2 cards have been drawn */
+  readonly phase2Complete = computed(() => this.gameSrv.givingCards().length >= 6);
+
+  /** Remaining cards in the draw pile */
+  readonly cardsRemaining = computed(
+    () => 12 - this.gameSrv.drinkingCards().length - this.gameSrv.givingCards().length
+  );
+
   ngOnDestroy(): void {
     this._animationTimers.forEach((id) => clearTimeout(id));
     this._animationTimers.length = 0;
@@ -269,6 +294,32 @@ export class FooterComponent implements OnDestroy {
     this.toastComponent?.show();
     await this.delay(2500);
     this.openSipGiveModal(this.gameSrv.getLastCard());
+  }
+
+  /** Draw the next card from the Phase 2 pile */
+  onDrawPhase2Card(): void {
+    if (this.revealingPhase2() || this.phase2Complete()) {
+      return;
+    }
+
+    const isDrink = this.nextIsDrink();
+    this.lastDrawnIsDrink.set(isDrink);
+    this.revealingPhase2.set(true);
+
+    const flipDelay = this.prefersReducedMotion ? 50 : 500;
+
+    // Draw the card (adds to drinkingCards/givingCards)
+    const newCard = this.gameSrv.displayNewCard();
+    this.lastDrawnCard.set(newCard ?? null);
+
+    // Wait for the flip animation, then unlock
+    this._scheduleTimer(() => {
+      this.revealingPhase2.set(false);
+      this.lastDrawnCard.set(null);
+      if (newCard) {
+        this.openSipGiveModal(newCard);
+      }
+    }, flipDelay);
   }
 
   hasPlayers(): boolean {

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -303,22 +303,24 @@ export class FooterComponent implements OnDestroy {
     }
 
     const isDrink = this.nextIsDrink();
-    this.lastDrawnIsDrink.set(isDrink);
-    this.revealingPhase2.set(true);
-
-    const flipDelay = this.prefersReducedMotion ? 50 : 500;
 
     // Draw the card (adds to drinkingCards/givingCards)
     const newCard = this.gameSrv.displayNewCard();
-    this.lastDrawnCard.set(newCard ?? null);
+    if (!newCard) {
+      return;
+    }
+
+    this.lastDrawnIsDrink.set(isDrink);
+    this.revealingPhase2.set(true);
+    this.lastDrawnCard.set(newCard);
+
+    const flipDelay = this.prefersReducedMotion ? 50 : 500;
 
     // Wait for the flip animation, then unlock
     this._scheduleTimer(() => {
       this.revealingPhase2.set(false);
       this.lastDrawnCard.set(null);
-      if (newCard) {
-        this.openSipGiveModal(newCard);
-      }
+      this.openSipGiveModal(newCard);
     }, flipDelay);
   }
 

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, OnDestroy, inject, signal, computed } from '@angular/core';
+import { Component, Input, ViewChild, OnDestroy, OnInit, inject, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgClass } from '@angular/common';
@@ -36,7 +36,7 @@ const PENDING_SUMMARY_KEY = 'pendingSummary';
     AccountGateModalComponent,
   ],
 })
-export class FooterComponent implements OnDestroy {
+export class FooterComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly authService = inject(AuthService);
   readonly gameSrv = inject(GameService);
@@ -98,6 +98,18 @@ export class FooterComponent implements OnDestroy {
   readonly cardsRemaining = computed(
     () => 12 - this.gameSrv.drinkingCards().length - this.gameSrv.givingCards().length
   );
+
+  ngOnInit(): void {
+    // If we land in Phase 2 with unassigned sips (e.g. after a page refresh
+    // mid-distribution), auto-reopen the give modal so the user isn't stuck.
+    if (this.gameSrv.isNotAllSipsGiven()) {
+      // Defer to next tick so all child components (player-card) have subscribed
+      // to openSipGiveModalEvent$ before we emit.
+      setTimeout(() => {
+        this.openSipGiveModal(this.gameSrv.getLastCard());
+      }, 0);
+    }
+  }
 
   ngOnDestroy(): void {
     this._animationTimers.forEach((id) => clearTimeout(id));

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -8,6 +8,7 @@ import { GameService } from '../../../services/game/game.service';
 import { SoloRoomService } from '../../../services/solo-room/solo-room.service';
 import { PlayerHelperService } from '../../_helpers/player.helper';
 import { CardType } from '../../_models/card-type.model';
+import { PlayerModel } from '../../_models/player.model';
 import { DrinkChoiceEnum } from '../../_models/enums/drink_choice.enum';
 import { ToastComponent } from '../toast/toast.component';
 import { PlayingCardComponent } from '../playing-card/playing-card.component';
@@ -59,6 +60,17 @@ export class FooterComponent implements OnDestroy {
   readonly predictionCorrect = signal<boolean | null>(null);
   /** The turn number during animation (null when not animating) */
   readonly animatingTurn = signal<number | null>(null);
+  /** The ID of the player who triggered the animation — frozen for the animation duration
+   * so the UI keeps showing that player's data even after `gameSrv.activePlayer()` advances. */
+  readonly animatingPlayerId = signal<string | null>(null);
+  /** Player to display in the prediction panel: frozen during animation, else the current active player. */
+  readonly displayPlayer = computed<PlayerModel | null>(() => {
+    const id = this.animatingPlayerId();
+    if (id) {
+      return this.gameSrv.players().find((p) => p.id === id) ?? this.gameSrv.activePlayer() ?? null;
+    }
+    return this.gameSrv.activePlayer() ?? null;
+  });
   /** Track if we're transitioning between turns */
   readonly turnTransitioning = signal(false);
 
@@ -106,7 +118,7 @@ export class FooterComponent implements OnDestroy {
 
   /** Reference card for Turn 2 (the card drawn in Turn 1 for the active player) */
   getReferenceCard(): CardType | null {
-    const activePlayer = this.gameSrv.activePlayer();
+    const activePlayer = this.displayPlayer();
     if (activePlayer?.cards?.length) {
       return activePlayer.cards[0];
     }
@@ -163,6 +175,7 @@ export class FooterComponent implements OnDestroy {
 
     // Phase 1: Button selected
     this.animatingTurn.set(currentTurn);
+    this.animatingPlayerId.set(activePlayerId ?? null);
     this.selectedChoice.set(selection);
     this.animationPhase.set('selected');
 
@@ -197,6 +210,7 @@ export class FooterComponent implements OnDestroy {
             this.revealedCard.set(null);
             this.predictionCorrect.set(null);
             this.animatingTurn.set(null);
+            this.animatingPlayerId.set(null);
             this.turnTransitioning.set(false);
           }, t.transition);
         }, t.result);

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -282,7 +282,7 @@ export class FooterComponent implements OnDestroy {
     return false;
   }
 
-  openSipGiveModal(newCardGiven: CardType): void {
+  openSipGiveModal(newCardGiven: CardType | undefined): void {
     if (!this.gameSrv.summary() || this.gameSrv.drinkingCards().length !== this.gameSrv.givingCards().length) {
       return;
     }

--- a/src/app/_shared/_components/footer/footer.component.ts
+++ b/src/app/_shared/_components/footer/footer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, OnDestroy, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, Input, ViewChild, OnDestroy, inject, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgClass } from '@angular/common';
@@ -36,7 +36,7 @@ const PENDING_SUMMARY_KEY = 'pendingSummary';
     AccountGateModalComponent,
   ],
 })
-export class FooterComponent implements OnInit, OnDestroy {
+export class FooterComponent implements OnDestroy {
   private readonly router = inject(Router);
   private readonly authService = inject(AuthService);
   readonly gameSrv = inject(GameService);
@@ -98,18 +98,6 @@ export class FooterComponent implements OnInit, OnDestroy {
   readonly cardsRemaining = computed(
     () => 12 - this.gameSrv.drinkingCards().length - this.gameSrv.givingCards().length
   );
-
-  ngOnInit(): void {
-    // If we land in Phase 2 with unassigned sips (e.g. after a page refresh
-    // mid-distribution), auto-reopen the give modal so the user isn't stuck.
-    if (this.gameSrv.isNotAllSipsGiven()) {
-      // Defer to next tick so all child components (player-card) have subscribed
-      // to openSipGiveModalEvent$ before we emit.
-      setTimeout(() => {
-        this.openSipGiveModal(this.gameSrv.getLastCard());
-      }, 0);
-    }
-  }
 
   ngOnDestroy(): void {
     this._animationTimers.forEach((id) => clearTimeout(id));

--- a/src/app/_shared/_components/game-progress/game-progress.component.spec.ts
+++ b/src/app/_shared/_components/game-progress/game-progress.component.spec.ts
@@ -223,14 +223,9 @@ describe('GameProgressComponent', () => {
       expect(container).toBeTruthy();
     });
 
-    it('should render phase label', () => {
-      const phaseLabel = fixture.debugElement.query(By.css('.phase-label'));
-      expect(phaseLabel).toBeTruthy();
-    });
-
-    it('should render stepper dots in phase 1', () => {
-      const dots = fixture.debugElement.query(By.css('.stepper-dots'));
-      expect(dots).toBeTruthy();
+    it('should render the BEM stepper container in phase 1', () => {
+      const stepper = fixture.debugElement.query(By.css('.stepper'));
+      expect(stepper).toBeTruthy();
     });
 
     it('should not render phase2-progress in phase 1', () => {
@@ -238,28 +233,28 @@ describe('GameProgressComponent', () => {
       expect(progress).toBeFalsy();
     });
 
-    it('should render 4 stepper dots', () => {
-      const dots = fixture.debugElement.queryAll(By.css('.stepper-dot'));
-      expect(dots.length).toBe(4);
+    it('should render 4 stepper steps', () => {
+      const steps = fixture.debugElement.queryAll(By.css('.stepper__step'));
+      expect(steps.length).toBe(4);
     });
 
-    it('should render turn label', () => {
-      const turnLabel = fixture.debugElement.query(By.css('.turn-label'));
-      expect(turnLabel).toBeTruthy();
+    it('should render a label for each stepper step', () => {
+      const labels = fixture.debugElement.queryAll(By.css('.stepper__label'));
+      expect(labels.length).toBe(4);
     });
 
-    it('should show active dot for current turn', () => {
+    it('should mark the current turn step as active', () => {
       turnSignal.set(2);
       fixture.detectChanges();
-      const activeDots = fixture.debugElement.queryAll(By.css('.stepper-dot.active'));
-      expect(activeDots.length).toBe(1);
+      const active = fixture.debugElement.queryAll(By.css('.stepper__step--active'));
+      expect(active.length).toBe(1);
     });
 
-    it('should show completed dots for previous turns', () => {
+    it('should mark previous-turn steps as completed', () => {
       turnSignal.set(3);
       fixture.detectChanges();
-      const completedDots = fixture.debugElement.queryAll(By.css('.stepper-dot.completed'));
-      expect(completedDots.length).toBe(2);
+      const completed = fixture.debugElement.queryAll(By.css('.stepper__step--completed'));
+      expect(completed.length).toBe(2);
     });
   });
 

--- a/src/app/_shared/_components/game-progress/game-progress.component.spec.ts
+++ b/src/app/_shared/_components/game-progress/game-progress.component.spec.ts
@@ -51,12 +51,12 @@ describe('GameProgressComponent', () => {
       expect(component.turn).toBeDefined();
     });
 
-    it('should have phase1TurnKeys defined', () => {
-      expect(component.phase1TurnKeys).toEqual([
-        'game.progress.turn.color',
-        'game.progress.turn.plusMinus',
-        'game.progress.turn.inOut',
-        'game.progress.turn.suit',
+    it('should have steps defined', () => {
+      expect(component.steps).toEqual([
+        { num: 1, icon: '🔴', labelKey: 'game.progress.turn.color' },
+        { num: 2, icon: '↕', labelKey: 'game.progress.turn.plusMinus' },
+        { num: 3, icon: '↔', labelKey: 'game.progress.turn.inOut' },
+        { num: 4, icon: '♠', labelKey: 'game.progress.turn.suit' },
       ]);
     });
   });
@@ -129,35 +129,36 @@ describe('GameProgressComponent', () => {
     });
   });
 
-  describe('currentTurnKey Computed', () => {
-    it('should return color key for turn 1', () => {
+  describe('Steps and Turn Mapping', () => {
+    it('should have step 1 active for turn 1', () => {
       turnSignal.set(1);
-      expect(component.currentTurnKey()).toBe('game.progress.turn.color');
+      expect(component.isStepActive(1)).toBeTrue();
     });
 
-    it('should return plusMinus key for turn 2', () => {
+    it('should have step 2 active for turn 2', () => {
       turnSignal.set(2);
-      expect(component.currentTurnKey()).toBe('game.progress.turn.plusMinus');
+      expect(component.isStepActive(2)).toBeTrue();
     });
 
-    it('should return inOut key for turn 3', () => {
+    it('should have step 3 active for turn 3', () => {
       turnSignal.set(3);
-      expect(component.currentTurnKey()).toBe('game.progress.turn.inOut');
+      expect(component.isStepActive(3)).toBeTrue();
     });
 
-    it('should return suit key for turn 4', () => {
+    it('should have step 4 active for turn 4', () => {
       turnSignal.set(4);
-      expect(component.currentTurnKey()).toBe('game.progress.turn.suit');
+      expect(component.isStepActive(4)).toBeTrue();
     });
 
-    it('should return empty string for turn 0', () => {
+    it('should have no step active for turn 0', () => {
       turnSignal.set(0);
-      expect(component.currentTurnKey()).toBe('');
+      expect(component.isStepActive(1)).toBeFalse();
+      expect(component.isStepActive(2)).toBeFalse();
     });
 
-    it('should return empty string for turn 5', () => {
+    it('should have no step active for turn 5', () => {
       turnSignal.set(5);
-      expect(component.currentTurnKey()).toBe('');
+      expect(component.isStepActive(4)).toBeFalse();
     });
   });
 
@@ -320,7 +321,8 @@ describe('GameProgressComponent', () => {
 
     it('should handle turn 0 gracefully', () => {
       turnSignal.set(0);
-      expect(component.currentTurnKey()).toBe('');
+      expect(component.isStepActive(1)).toBeFalse();
+      expect(component.isStepCompleted(1)).toBeFalse();
     });
 
     it('should handle empty card arrays in phase 2', () => {

--- a/src/app/_shared/_components/playing-card/playing-card.component.html
+++ b/src/app/_shared/_components/playing-card/playing-card.component.html
@@ -1,9 +1,34 @@
-<div
-  class="card-container d-flex flex-column justify-content-center"
-  [ngClass]="{
-    emphasis: card?.selected,
-    'left-overlap': leftOverlap,
-  }"
->
-  <img [src]="card?.img ?? 'assets/images/cards/svg/blue_back.svg'" alt="{{ card?.value }} {{ card?.suit }}" />
-</div>
+@if (faceDown) {
+  <!-- Phase 2 flip mode: card starts face-down, flips on reveal -->
+  <div
+    class="card-container"
+    [ngClass]="{
+      emphasis: card?.selected,
+      'left-overlap': leftOverlap,
+      'card-container--glow-red': flipped && glowColor === 'red',
+      'card-container--glow-green': flipped && glowColor === 'green',
+      'card-container--tappable': tappable,
+    }"
+    (click)="onCardClick()"
+  >
+    <div class="card-flip" [class.card-flip--flipped]="flipped">
+      <div class="card-flip__back">
+        <img src="assets/images/cards/svg/blue_back.svg" alt="card back" />
+      </div>
+      <div class="card-flip__front">
+        <img [src]="card?.img ?? 'assets/images/cards/svg/blue_back.svg'" alt="{{ card?.value }} {{ card?.suit }}" />
+      </div>
+    </div>
+  </div>
+} @else {
+  <!-- Default mode: card face shown immediately (Phase 1, player hands) -->
+  <div
+    class="card-container d-flex flex-column justify-content-center"
+    [ngClass]="{
+      emphasis: card?.selected,
+      'left-overlap': leftOverlap,
+    }"
+  >
+    <img [src]="card?.img ?? 'assets/images/cards/svg/blue_back.svg'" alt="{{ card?.value }} {{ card?.suit }}" />
+  </div>
+}

--- a/src/app/_shared/_components/playing-card/playing-card.component.scss
+++ b/src/app/_shared/_components/playing-card/playing-card.component.scss
@@ -25,4 +25,88 @@
     height: auto;
     border-radius: var(--radius-sm, 3px);
   }
+
+  // Phase 2 glow colors
+  &--glow-red {
+    box-shadow:
+      0 0 10px rgba(220, 38, 38, 0.5),
+      0 0 20px rgba(220, 38, 38, 0.25);
+    border-radius: var(--radius-sm, 3px);
+  }
+
+  &--glow-green {
+    box-shadow:
+      0 0 10px rgba(34, 197, 94, 0.5),
+      0 0 20px rgba(34, 197, 94, 0.25);
+    border-radius: var(--radius-sm, 3px);
+  }
+
+  // Tappable card (next to reveal in pyramid)
+  &--tappable {
+    cursor: pointer;
+    animation: tap-pulse 1.5s ease-in-out infinite;
+
+    &:active {
+      transform: scale(0.95);
+    }
+  }
+}
+
+// 3D card flip
+.card-flip {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: inherit;
+  transform-style: preserve-3d;
+  transition: transform 400ms var(--ease-in-out, ease-in-out);
+
+  &--flipped {
+    transform: rotateY(180deg);
+  }
+
+  &__back,
+  &__front {
+    position: absolute;
+    inset: 0;
+    backface-visibility: hidden;
+    border-radius: var(--radius-sm, 3px);
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border-radius: var(--radius-sm, 3px);
+    }
+  }
+
+  &__front {
+    transform: rotateY(180deg);
+  }
+}
+
+// When faceDown mode is active, add perspective to container
+.card-container:has(.card-flip) {
+  perspective: 600px;
+}
+
+@keyframes tap-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(99, 102, 241, 0);
+  }
+}
+
+// Reduced motion
+@media (prefers-reduced-motion: reduce) {
+  .card-flip {
+    transition-duration: 0.01ms !important;
+  }
+  .card-container--tappable {
+    animation: none;
+  }
 }

--- a/src/app/_shared/_components/playing-card/playing-card.component.ts
+++ b/src/app/_shared/_components/playing-card/playing-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { CardType } from '../../_models/card-type.model';
 
@@ -12,4 +12,20 @@ import { CardType } from '../../_models/card-type.model';
 export class PlayingCardComponent {
   @Input() card: CardType | undefined;
   @Input() leftOverlap = false;
+  /** When true, card starts face-down and flips when `flipped` becomes true */
+  @Input() faceDown = false;
+  /** Whether the face-down card has been flipped to reveal its face */
+  @Input() flipped = false;
+  /** Glow color for Phase 2 distinction: 'red' (drink), 'green' (give), 'none' */
+  @Input() glowColor: 'red' | 'green' | 'none' = 'none';
+  /** Whether this card can be tapped (next card in pyramid) */
+  @Input() tappable = false;
+  /** Emitted when a tappable card is tapped */
+  @Output() cardTapped = new EventEmitter<void>();
+
+  onCardClick(): void {
+    if (this.tappable) {
+      this.cardTapped.emit();
+    }
+  }
 }

--- a/src/app/_shared/_helpers/player.helper.spec.ts
+++ b/src/app/_shared/_helpers/player.helper.spec.ts
@@ -582,11 +582,10 @@ describe('PlayerHelperService', () => {
     });
 
     describe('Phase 2+ behavior', () => {
-      it('should return 0 when no drinking/giving cards in phase 2', () => {
-        player1.cards = [createMockCard({ sips: 4 })];
+      it('should return 0 when player has no sips in phase 2', () => {
+        player1.sips = { drunk: 0, given: 0 };
         const game = createMockGame({
           players: [player1, player2, player3],
-          activePlayer: player2,
           phase: 2,
           drinkingCards: [],
           givingCards: [],
@@ -597,113 +596,104 @@ describe('PlayerHelperService', () => {
         expect(result).toBe(0);
       });
 
-      it('should calculate sips based on matching card values with odd total cards', () => {
-        const drinkingCard = createMockCard({ value: '5' });
-        player1.cards = [createMockCard({ value: '5' })];
-        cardServiceSpy.getCardValue.and.callFake((card: CardType) => {
-          return card.value === '5' ? 5 : 0;
-        });
-
+      it('should return negative value for drunk sips in phase 2', () => {
+        player1.sips = { drunk: 5, given: 0 };
         const game = createMockGame({
           players: [player1, player2, player3],
-          activePlayer: player2,
           phase: 2,
-          drinkingCards: [drinkingCard],
+          drinkingCards: [],
           givingCards: [],
         });
 
         const result = service.getSipCnt(game, player1);
 
-        // Odd cards (1), so negative multiplier: 1 * -1 = -1
-        expect(result).toBe(-1);
+        expect(result).toBe(-5);
       });
 
-      it('should calculate sips based on matching card values with even total cards', () => {
-        const drinkingCard = createMockCard({ value: '7' });
-        const givingCard = createMockCard({ value: '7' });
-        player1.cards = [createMockCard({ value: '7' })];
-        cardServiceSpy.getCardValue.and.callFake((card: CardType) => {
-          return card.value === '7' ? 7 : 0;
-        });
-
+      it('should return positive value for given sips in phase 2', () => {
+        player1.sips = { drunk: 0, given: 3 };
         const game = createMockGame({
           players: [player1, player2, player3],
-          activePlayer: player2,
           phase: 2,
-          drinkingCards: [drinkingCard],
-          givingCards: [givingCard],
+          drinkingCards: [],
+          givingCards: [],
         });
 
         const result = service.getSipCnt(game, player1);
 
-        // Even cards (2), positive multiplier: 1 * 1 = 1
-        expect(result).toBe(1);
+        expect(result).toBe(3);
       });
 
-      it('should return 0 when no matching cards', () => {
-        const drinkingCard = createMockCard({ value: '5' });
-        player1.cards = [createMockCard({ value: '10' })];
-        cardServiceSpy.getCardValue.and.callFake((card: CardType) => {
-          return card.value === '5' ? 5 : 10;
-        });
-
+      it('should return net sips (given - drunk) in phase 2', () => {
+        player1.sips = { drunk: 4, given: 7 };
         const game = createMockGame({
           players: [player1, player2, player3],
-          activePlayer: player2,
           phase: 2,
-          drinkingCards: [drinkingCard],
+          drinkingCards: [],
+          givingCards: [],
+        });
+
+        const result = service.getSipCnt(game, player1);
+
+        expect(result).toBe(3);
+      });
+
+      it('should return total sips (drunk + given) when absolute is true in phase 2', () => {
+        player1.sips = { drunk: 5, given: 3 };
+        const game = createMockGame({
+          players: [player1, player2, player3],
+          phase: 2,
+          drinkingCards: [],
+          givingCards: [],
+        });
+
+        const result = service.getSipCnt(game, player1, true);
+
+        expect(result).toBe(8);
+      });
+
+      it('should subtract phase1Drunk from total drunk in phase 2', () => {
+        player1.sips = { drunk: 12, given: 0, phase1Drunk: 4 };
+        const game = createMockGame({
+          players: [player1, player2, player3],
+          phase: 2,
+          drinkingCards: [],
+          givingCards: [],
+        });
+
+        const result = service.getSipCnt(game, player1);
+
+        // Phase 2 drunk = 12 - 4 = 8, given = 0 → net = 0 - 8 = -8
+        expect(result).toBe(-8);
+      });
+
+      it('should subtract phase1Drunk in absolute mode too', () => {
+        player1.sips = { drunk: 12, given: 3, phase1Drunk: 4 };
+        const game = createMockGame({
+          players: [player1, player2, player3],
+          phase: 2,
+          drinkingCards: [],
+          givingCards: [],
+        });
+
+        const result = service.getSipCnt(game, player1, true);
+
+        // Phase 2 drunk = 12 - 4 = 8, given = 3 → absolute = 8 + 3 = 11
+        expect(result).toBe(11);
+      });
+
+      it('should handle undefined sips gracefully in phase 2', () => {
+        player1.sips = undefined as any;
+        const game = createMockGame({
+          players: [player1, player2, player3],
+          phase: 2,
+          drinkingCards: [],
           givingCards: [],
         });
 
         const result = service.getSipCnt(game, player1);
 
         expect(result).toBe(0);
-      });
-
-      it('should multiply sips by number of drinking cards', () => {
-        const drinkingCards = [
-          createMockCard({ value: '5' }),
-          createMockCard({ value: '6' }),
-          createMockCard({ value: '5' }),
-        ];
-        player1.cards = [createMockCard({ value: '5' }), createMockCard({ value: '5' })];
-        cardServiceSpy.getCardValue.and.callFake((card: CardType) => {
-          return card.value === '5' ? 5 : 6;
-        });
-
-        const game = createMockGame({
-          players: [player1, player2, player3],
-          activePlayer: player2,
-          phase: 2,
-          drinkingCards: drinkingCards,
-          givingCards: [],
-        });
-
-        const result = service.getSipCnt(game, player1);
-
-        // Odd (3), check last drinking card which is '5', player has 2 matching cards
-        // 2 * 3 * -1 = -6
-        expect(result).toBe(-6);
-      });
-
-      it('should return absolute value when absolute is true in phase 2', () => {
-        const drinkingCard = createMockCard({ value: '5' });
-        player1.cards = [createMockCard({ value: '5' })];
-        cardServiceSpy.getCardValue.and.callFake((card: CardType) => {
-          return card.value === '5' ? 5 : 0;
-        });
-
-        const game = createMockGame({
-          players: [player1, player2, player3],
-          activePlayer: player2,
-          phase: 2,
-          drinkingCards: [drinkingCard],
-          givingCards: [],
-        });
-
-        const result = service.getSipCnt(game, player1, true);
-
-        expect(result).toBe(1);
       });
     });
   });

--- a/src/app/_shared/_helpers/player.helper.ts
+++ b/src/app/_shared/_helpers/player.helper.ts
@@ -63,7 +63,7 @@ export class PlayerHelperService {
   }
 
   getSipCnt(game: Game, player: PlayerModel, absolute: boolean = false) {
-    const { drinkingCards, givingCards, phase } = game;
+    const { phase } = game;
     const maybeAbs = absolute ? Math.abs : (v: number) => v;
 
     if (phase === 1) {
@@ -75,28 +75,18 @@ export class PlayerHelperService {
       return maybeAbs(totalSips);
     }
 
-    // No cards to compare yet
-    if (drinkingCards.length === 0 && givingCards.length === 0) {
-      return 0;
+    // Phase 2: use accumulated sips stored in player.sips (Phase 2 only)
+    const totalDrunk = player.sips?.['drunk'] ?? 0;
+    const phase1Drunk = player.sips?.['phase1Drunk'] ?? 0;
+    const drunk = totalDrunk - phase1Drunk;
+    const given = player.sips?.['given'] ?? 0;
+
+    if (absolute) {
+      return drunk + given;
     }
 
-    let cntNbSips = 0;
-    const isOdd = (drinkingCards.length + givingCards.length) % 2 === 1;
-    const lastCard = isOdd ? drinkingCards.at(-1) : givingCards.at(-1);
-
-    if (!lastCard) {
-      return 0;
-    }
-
-    const lastCardValue = this.cardSrv.getCardValue(lastCard);
-    for (const card of player.cards) {
-      const playerCardValue = this.cardSrv.getCardValue(card);
-      if (playerCardValue === lastCardValue) {
-        cntNbSips += drinkingCards.length * (isOdd ? -1 : 1);
-      }
-    }
-
-    return maybeAbs(cntNbSips);
+    // Signed: negative = drink, positive = give
+    return given - drunk;
   }
 
   getTotalGivenSips(player: PlayerModel): number {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -36,6 +36,7 @@ describe('AppComponent', () => {
     summary: ReturnType<typeof signal<boolean>>;
     isNewGame: jasmine.Spy;
     handleReconnection: jasmine.Spy;
+    clearPersistedSummary: jasmine.Spy;
   };
   let mockPlayerHelperService: jasmine.SpyObj<PlayerHelperService>;
   let mockAuthService: ReturnType<typeof createMockAuthService>;
@@ -50,6 +51,7 @@ describe('AppComponent', () => {
       summary: summarySignal,
       isNewGame: jasmine.createSpy('isNewGame').and.returnValue(true),
       handleReconnection: jasmine.createSpy('handleReconnection').and.resolveTo(undefined),
+      clearPersistedSummary: jasmine.createSpy('clearPersistedSummary'),
     };
 
     mockPlayerHelperService = jasmine.createSpyObj('PlayerHelperService', ['getPlayerNumber']);
@@ -103,6 +105,15 @@ describe('AppComponent', () => {
   });
 
   describe('withSummaryMode computed signal', () => {
+    // The computed short-circuits to false for anonymous/logged-out users so a
+    // summary flag inherited from a prior session can't leak into Partie rapide.
+    // These tests cover the connected non-anonymous path; anonymous behavior is
+    // covered separately below.
+    beforeEach(() => {
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(false);
+    });
+
     it('should return false when withSummaryMode signal is false and summary is false', () => {
       fixture.detectChanges();
 
@@ -149,6 +160,29 @@ describe('AppComponent', () => {
       mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
       mockGameService.withSummaryMode.set(false);
       mockGameService.summary.set(false);
+
+      expect(component.withSummaryMode()).toBe(false);
+    });
+
+    it('should return false for anonymous users even with summary signals true', () => {
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(true);
+      fixture.detectChanges();
+
+      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
+      mockGameService.withSummaryMode.set(true);
+      mockGameService.summary.set(true);
+
+      expect(component.withSummaryMode()).toBe(false);
+    });
+
+    it('should return false for logged-out users even with summary signals true', () => {
+      mockAuthService.isLoggedIn.set(false);
+      fixture.detectChanges();
+
+      mockPlayerHelperService.getPlayerNumber.and.returnValue(2);
+      mockGameService.withSummaryMode.set(true);
+      mockGameService.summary.set(true);
 
       expect(component.withSummaryMode()).toBe(false);
     });
@@ -295,6 +329,11 @@ describe('AppComponent', () => {
   });
 
   describe('Signal reactivity', () => {
+    beforeEach(() => {
+      mockAuthService.isLoggedIn.set(true);
+      mockAuthService.isAnonymous.set(false);
+    });
+
     it('should update withSummaryMode when signal changes', () => {
       fixture.detectChanges();
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -42,9 +42,7 @@ export class AppComponent implements OnInit {
    * result and not re-evaluate on route changes.
    */
   canShowSummary(): boolean {
-    return this.isPlayersPage()
-      && this.authService.isLoggedIn()
-      && !this.authService.isAnonymous();
+    return this.isPlayersPage() && this.authService.isLoggedIn() && !this.authService.isAnonymous();
   }
 
   constructor() {
@@ -53,6 +51,11 @@ export class AppComponent implements OnInit {
     this.translate.use(defaultLang);
 
     this.withSummaryMode = computed(() => {
+      // Anonymous/logged-out users have no summary checkbox and must not get summary features
+      // (the withSummaryMode signal persists in localStorage and can leak across auth states).
+      if (!this.authService.isLoggedIn() || this.authService.isAnonymous()) {
+        return false;
+      }
       const summaryMode = this.gameSrv.withSummaryMode();
       const gameSummary = this.gameSrv.summary();
       return this.playerSrv.getPlayerNumber() > 1 ? summaryMode || gameSummary : summaryMode;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -70,6 +70,10 @@ export class AppComponent implements OnInit {
     try {
       await this.authService.init();
 
+      if (this.authService.isAnonymous()) {
+        this.gameSrv.clearPersistedSummary();
+      }
+
       if (this.authService.isLoggedIn()) {
         const activeSession = await this.soloRoomService.checkActiveSession();
         if (activeSession) {

--- a/src/app/services/game/game.service.spec.ts
+++ b/src/app/services/game/game.service.spec.ts
@@ -1893,7 +1893,7 @@ describe('GameService', () => {
 
         const result = testService.getLastCard();
 
-        expect(result.value).toBe('K');
+        expect(result?.value).toBe('K');
       });
 
       it('should return last drinking card when drinkingCards > givingCards', () => {
@@ -1906,7 +1906,7 @@ describe('GameService', () => {
 
         const result = testService.getLastCard();
 
-        expect(result.value).toBe('5');
+        expect(result?.value).toBe('5');
       });
     });
 

--- a/src/app/services/game/game.service.spec.ts
+++ b/src/app/services/game/game.service.spec.ts
@@ -1421,7 +1421,8 @@ describe('GameService', () => {
       expect(testService.getLastTurnSipsForPlayer('player-1')).toBe(1);
     });
 
-    it('should keep lastTurnSips when entering Phase 2 and clear on first Phase 2 card', () => {
+    it('should keep lastTurnSips when entering Phase 2 and reset on first Phase 2 card draw', () => {
+      // Player has 3 hand cards all with default value '5' (from createMockCard).
       const player = createMockPlayer({
         id: 'player-1',
         cards: [createMockCard(), createMockCard(), createMockCard()],
@@ -1435,17 +1436,22 @@ describe('GameService', () => {
       });
       const testService = createServiceWithGame(mockGame);
 
-      const newCard = createMockCard();
-      mockCardDeckHelperService.getRandomCard.and.returnValue(newCard);
+      // Turn-4 pickCard returns a value '5' card. Suit prediction wrong → 4 sips.
+      const drawnPhase1Card = createMockCard();
+      mockCardDeckHelperService.getRandomCard.and.returnValue(drawnPhase1Card);
       mockPlayerHelperService.getPlayerChoice.and.returnValue('spades');
 
       testService.pickCard();
 
-      // lastTurnSips should persist after Phase 2 transition (wrong suit = 4 sips)
+      // lastTurnSips persists across the Phase 1 → Phase 2 transition.
       expect(testService.game().phase).toBe(2);
       expect(testService.getLastTurnSipsForPlayer('player-1')).toBe(4);
 
-      // Clear on first Phase 2 card draw
+      // First Phase 2 card draw: use a card with a value the player does NOT
+      // hold so the per-draw map stays empty (otherwise the new effect would
+      // populate it with the count of matching hand cards).
+      const phase2Card = createMockCard({ value: 'K', suit: 'clubs' });
+      mockCardDeckHelperService.getRandomCard.and.returnValue(phase2Card);
       testService.displayNewCard();
       expect(testService.getLastTurnSipsForPlayer('player-1')).toBe(0);
     });
@@ -1733,7 +1739,7 @@ describe('GameService', () => {
 
       testService.resetGame();
 
-      expect(testService.game().players[0].sips).toEqual({ drunk: 0, given: 0 });
+      expect(testService.game().players[0].sips).toEqual({ drunk: 0, given: 0, phase1Drunk: 0 });
       expect(testService.game().players[0].cards).toEqual([]);
       expect(testService.game().players[0].choice).toEqual({
         color: '',

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -111,16 +111,81 @@ export class GameService {
   private readonly openSipGiveModalEvent = new Subject<PlayerModel>();
   readonly openSipGiveModalEvent$ = this.openSipGiveModalEvent.asObservable();
 
+  /** Previous Phase 2 card counts per array, used to detect newly-added cards in
+   * the sync effect below. Updated on every tick. */
+  private _prevDrinkLen = 0;
+  private _prevGiveLen = 0;
+
   constructor() {
     // Persist summary mode preference to localStorage on every change
     effect(() => {
       localStorage.setItem(GameService.SUMMARY_MODE_KEY, String(this.withSummaryMode()));
     });
 
+    // Detect newly-added Phase 2 cards (local OR via realtime sync in room mode)
+    // and populate the per-draw badge signals. This makes the pink/orange per-draw
+    // badges visible to remote clients that receive the update via KetalSession
+    // realtime sync — they never enter displayNewCard themselves.
+    effect(() => {
+      const game = this._game();
+      if (!game || game.phase !== 2) {
+        this._prevDrinkLen = 0;
+        this._prevGiveLen = 0;
+        return;
+      }
+      const drinkLen = game.drinkingCards?.length ?? 0;
+      const giveLen = game.givingCards?.length ?? 0;
+      const newDrink = drinkLen > this._prevDrinkLen;
+      const newGive = giveLen > this._prevGiveLen;
+      this._prevDrinkLen = drinkLen;
+      this._prevGiveLen = giveLen;
+      if (!newDrink && !newGive) {
+        return;
+      }
+      const latestCard = newGive ? game.givingCards?.[giveLen - 1] : game.drinkingCards?.[drinkLen - 1];
+      if (!latestCard) {
+        return;
+      }
+      const { drinkMap, giveMap } = this.computeTurnMapsForCard(latestCard, newGive, game.players ?? []);
+      this._lastTurnSips.set(drinkMap);
+      this._lastTurnGiven.set(giveMap);
+    });
+
     // Register cleanup on service destruction
     this.destroyRef.onDestroy(() => {
       this.unsubscribeFromSession();
     });
+  }
+
+  /** Pure helper: for a newly drawn Phase 2 card, compute which players match
+   * (they have a card of the same value in hand) and what sip count each owes. */
+  private computeTurnMapsForCard(
+    card: CardType,
+    isGiving: boolean,
+    players: PlayerModel[]
+  ): { drinkMap: Record<string, number>; giveMap: Record<string, number> } {
+    const sipNb = card.sips ?? 0;
+    const drinkMap: Record<string, number> = {};
+    const giveMap: Record<string, number> = {};
+    if (sipNb <= 0) {
+      return { drinkMap, giveMap };
+    }
+    players.forEach((player) => {
+      let sipTurnNb = 0;
+      player.cards?.forEach((c) => {
+        if (c.value === card.value) {
+          sipTurnNb += sipNb;
+        }
+      });
+      if (sipTurnNb > 0 && (player.cards?.length ?? 0) >= 4) {
+        if (isGiving) {
+          giveMap[player.id] = sipTurnNb;
+        } else {
+          drinkMap[player.id] = sipTurnNb;
+        }
+      }
+    });
+    return { drinkMap, giveMap };
   }
 
   private loadGameFromStorage(): Game | null {
@@ -381,6 +446,20 @@ export class GameService {
   }
 
   /**
+   * Force the persisted `summary` flag to false. Called at auth resolution
+   * for anonymous users so a summary flag inherited from a prior logged-in
+   * session cannot leak into Partie rapide.
+   */
+  clearPersistedSummary(): void {
+    const game = this._game();
+    if (game && game.summary) {
+      this.updateGame((g) => {
+        g.summary = false;
+      });
+    }
+  }
+
+  /**
    * Save game state and notify subscribers via signal update.
    * Routes to appropriate persistence layer based on game mode.
    */
@@ -480,8 +559,9 @@ export class GameService {
     this.activeSessionId = null;
     this._pendingSessionUpdate = null;
     this._pendingGameSync = null;
-    // Clear per-turn sip indicator
+    // Clear per-turn sip indicators (both drink and give)
     this._lastTurnSips.set({});
+    this._lastTurnGiven.set({});
 
     // Clean up solo room state and leave room
     this.soloRoomService.reset();
@@ -655,12 +735,12 @@ export class GameService {
       }
 
       // In Phase 2, a drink event (received via give-modal distribution) must
-      // show on the red per-event badge for the receiving player. Accumulate so
-      // multi-player modal saves don't overwrite each other.
+      // show on the orange per-event badge for the receiving player. The map is
+      // keyed by player ID so different recipients in the same modal save don't
+      // collide; we overwrite (not accumulate) so a duplicate save on the same
+      // player replaces instead of doubling the badge.
       if (drink && game.phase === 2 && (currPlayer.cards?.length ?? 0) >= 4) {
-        const map = { ...this._lastTurnSips() };
-        map[currPlayer.id] = (map[currPlayer.id] ?? 0) + sipNbr;
-        this._lastTurnSips.set(map);
+        this._lastTurnSips.set({ ...this._lastTurnSips(), [currPlayer.id]: sipNbr });
       }
     });
   }

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -93,6 +93,9 @@ export class GameService {
   private readonly _lastTurnSips = signal<Record<string, number>>({});
   readonly lastTurnSips = this._lastTurnSips.asReadonly();
 
+  /** Phase 2: value of the last revealed card (for match feedback in player-card) */
+  readonly phase2LastCardValue = signal<string | null>(null);
+
   /** localStorage key for summary mode preference */
   private static readonly SUMMARY_MODE_KEY = 'ketal_summary_mode';
 
@@ -778,6 +781,9 @@ export class GameService {
 
     const sipNb = this.getSipsNumber();
     newCard.sips = sipNb;
+
+    // Set Phase 2 match value for player-card feedback
+    this.phase2LastCardValue.set(newCard.value ?? null);
 
     // Determine if this is a giving card BEFORE mutating the game state.
     // This is safe because JavaScript is single-threaded: no concurrent mutation

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -850,7 +850,10 @@ export class GameService {
     return remainingSipsToGive > 0;
   }
 
-  getLastCard(): CardType {
+  /** Returns the most recently revealed Phase 2 card (give pile takes precedence
+   * when both arrays are equal length). Returns `undefined` when no card has
+   * been drawn yet — both call sites in footer already null-check the result. */
+  getLastCard(): CardType | undefined {
     const giving = this.givingCards();
     const drinking = this.drinkingCards();
     if (giving.length >= drinking.length) {

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -92,6 +92,11 @@ export class GameService {
    */
   private readonly _lastTurnSips = signal<Record<string, number>>({});
   readonly lastTurnSips = this._lastTurnSips.asReadonly();
+  /** Per-draw give sips per player (Phase 2 give card matches) so the UI can show
+   * a short-lived "you must give N sips this turn" badge even when summary is off
+   * and no modal/pending counter is available. Cleared on each next card draw. */
+  private readonly _lastTurnGiven = signal<Record<string, number>>({});
+  readonly lastTurnGiven = this._lastTurnGiven.asReadonly();
 
   /** Phase 2: value of the last revealed card (for match feedback in player-card) */
   readonly phase2LastCardValue = signal<string | null>(null);
@@ -648,6 +653,15 @@ export class GameService {
       } else {
         currPlayer.sips[drink ? 'drunk' : 'given'] += sipNbr;
       }
+
+      // In Phase 2, a drink event (received via give-modal distribution) must
+      // show on the red per-event badge for the receiving player. Accumulate so
+      // multi-player modal saves don't overwrite each other.
+      if (drink && game.phase === 2 && (currPlayer.cards?.length ?? 0) >= 4) {
+        const map = { ...this._lastTurnSips() };
+        map[currPlayer.id] = (map[currPlayer.id] ?? 0) + sipNbr;
+        this._lastTurnSips.set(map);
+      }
     });
   }
 
@@ -775,10 +789,11 @@ export class GameService {
       return;
     }
 
-    // Clear Phase 1 per-turn sip indicators on first Phase 2 card draw
-    if (Object.keys(this._lastTurnSips()).length > 0) {
-      this._lastTurnSips.set({});
-    }
+    // Reset per-event indicators on every Phase 2 card draw; for a drink card we
+    // populate drink matches below, for a give card we populate give matches so the
+    // giver gets a "+N to give this turn" badge even when no modal/pending counter exists.
+    this._lastTurnSips.set({});
+    this._lastTurnGiven.set({});
 
     const newCard = this.cardDeckHelperService.getRandomCard();
     newCard.selected = true;
@@ -813,7 +828,9 @@ export class GameService {
         });
       });
 
-      // Add sips to players
+      // Add sips to players and track per-draw amounts for badge display
+      const turnSipsMap: Record<string, number> = {};
+      const turnGivenMap: Record<string, number> = {};
       g.players?.forEach((player) => {
         player.sips ??= { drunk: 0, given: 0 };
         let sipTurnNb = 0;
@@ -828,8 +845,17 @@ export class GameService {
           } else {
             player.sips[!isGiving ? 'drunk' : 'given'] += sipTurnNb;
           }
+          // Drink card → matched players drink this event; Give card → matched players
+          // must give this event (each tracked for their own badge).
+          if (isGiving) {
+            turnGivenMap[player.id] = sipTurnNb;
+          } else {
+            turnSipsMap[player.id] = sipTurnNb;
+          }
         }
       });
+      this._lastTurnSips.set(turnSipsMap);
+      this._lastTurnGiven.set(turnGivenMap);
 
       // Add the card to the appropriate array
       if (isGiving) {
@@ -1032,6 +1058,11 @@ export class GameService {
    */
   getLastTurnSipsForPlayer(playerId: string): number {
     return this._lastTurnSips()[playerId] ?? 0;
+  }
+
+  /** Get the per-draw give sips for a player (Phase 2 give card match). */
+  getLastTurnGivenForPlayer(playerId: string): number {
+    return this._lastTurnGiven()[playerId] ?? 0;
   }
 
   openSipGiveModal(player: PlayerModel): void {

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -699,6 +699,10 @@ export class GameService {
         if (g.turn > 4) {
           g.phase = 2;
           g.activePlayer = undefined;
+          // Snapshot Phase 1 sips so Phase 2 display shows only Phase 2 sips
+          g.players.forEach((p) => {
+            p.sips['phase1Drunk'] = p.sips['drunk'] || 0;
+          });
           // Keep lastTurnSips visible until first Phase 2 card is drawn
         } else {
           g.activePlayer = g.players[0];

--- a/src/app/services/game/game.service.ts
+++ b/src/app/services/game/game.service.ts
@@ -491,7 +491,7 @@ export class GameService {
       game.status = 0;
 
       game.players.forEach((player) => {
-        player.sips = { drunk: 0, given: 0 };
+        player.sips = { drunk: 0, given: 0, phase1Drunk: 0 };
         player.cards = [];
         player.choice = { color: '', plus_or_minus: '', in_out: '', suit: '' };
       });
@@ -786,8 +786,9 @@ export class GameService {
     const sipNb = this.getSipsNumber();
     newCard.sips = sipNb;
 
-    // Set Phase 2 match value for player-card feedback
+    // Set Phase 2 match value for player-card feedback, then clear after highlight window
     this.phase2LastCardValue.set(newCard.value ?? null);
+    setTimeout(() => this.phase2LastCardValue.set(null), 2100);
 
     // Determine if this is a giving card BEFORE mutating the game state.
     // This is safe because JavaScript is single-threaded: no concurrent mutation

--- a/src/app/testing/test-helpers.ts
+++ b/src/app/testing/test-helpers.ts
@@ -29,7 +29,16 @@ export function createMockAuthService(): jasmine.SpyObj<AuthService> & {
 
   const mock = jasmine.createSpyObj(
     'AuthService',
-    ['init', 'signUp', 'loginWithEmail', 'signInWithGoogle', 'logout', 'createAnonymousSession', 'getOrCreateSession', 'consumePendingSummary'],
+    [
+      'init',
+      'signUp',
+      'loginWithEmail',
+      'signInWithGoogle',
+      'logout',
+      'createAnonymousSession',
+      'getOrCreateSession',
+      'consumePendingSummary',
+    ],
     {
       currentUser: signal(null),
       isLoggedIn: mockIsLoggedIn,
@@ -96,6 +105,8 @@ export function createMockGameService(): jasmine.SpyObj<GameService> & {
       'updatePlayerGivenSipsFromCard',
       'openSipGiveModal',
       'getLastTurnSipsForPlayer',
+      'getLastTurnGivenForPlayer',
+      'clearPersistedSummary',
     ],
     {
       withSummaryMode: mockWithSummaryMode,
@@ -112,9 +123,12 @@ export function createMockGameService(): jasmine.SpyObj<GameService> & {
       isRoomMode: signal(false),
       openSipGiveModalEvent$: NEVER,
       lastTurnSips: signal<Record<string, number>>({}),
+      lastTurnGiven: signal<Record<string, number>>({}),
+      phase2LastCardValue: signal<string | null>(null),
     }
   );
   mock.getLastTurnSipsForPlayer.and.returnValue(0);
+  mock.getLastTurnGivenForPlayer.and.returnValue(0);
   mock.isNewGame.and.returnValue(true);
   mock.isGameStarted.and.returnValue(false);
   mock.isGameFinished.and.returnValue(false);
@@ -353,7 +367,17 @@ export function createMockMemberService(): jasmine.SpyObj<MemberService> & {
 export function createMockRealtimeService(): jasmine.SpyObj<RealtimeService> {
   const mock = jasmine.createSpyObj(
     'RealtimeService',
-    ['subscribeToRoom', 'subscribeToSession', 'subscribeToDocument', 'subscribeToMembers', 'subscribeToCollection', 'unsubscribe', 'unsubscribeAll', 'hasSubscription', 'getActiveSubscriptionIds'],
+    [
+      'subscribeToRoom',
+      'subscribeToSession',
+      'subscribeToDocument',
+      'subscribeToMembers',
+      'subscribeToCollection',
+      'unsubscribe',
+      'unsubscribeAll',
+      'hasSubscription',
+      'getActiveSubscriptionIds',
+    ],
     {
       isConnected: signal(true),
       activeSubscriptions: signal(0),

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -19,6 +19,7 @@
   "Button_GoToMenu": "Pause",
   "Button_ResumeGame": "Spiel läuft - Fortsetzen",
   "Button_Cancel": "Abbrechen",
+  "Button_Confirm": "Bestätigen",
   "Dialog_QuitConfirmMessage": "Spiel zurücksetzen? Alle Daten gehen verloren.",
   "Button_Create": "Erstellen",
   "Button_Delete": "Löschen",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -29,6 +29,7 @@
   "Button_In": "Drinnen",
   "Button_Out": "Draußen",
   "Remaining_Sips": "Schlucke",
+  "Sip_Modal_Hint": "Tippe auf einen Spieler, um ihm einen Schluck zu geben",
   "Label_Sip": "Schluck",
   "Label_Sips": "Schlücke",
   "Warning": "Warnung",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -218,6 +218,9 @@
       "correct": "Prediction correct",
       "incorrect": "Prediction incorrect"
     },
+    "phase2": {
+      "drawPile": "Draw pile"
+    },
     "progress": {
       "phase1": "Phase 1: Predictions",
       "phase2": "Phase 2: Distribution",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -22,6 +22,7 @@
   "Button_GoToMenu": "Pause",
   "Button_ResumeGame": "Game in progress - Resume",
   "Button_Cancel": "Cancel",
+  "Button_Confirm": "Confirm",
   "Dialog_QuitConfirmMessage": "Reset the game? All data will be lost.",
   "Button_Create": "Create",
   "Button_Delete": "Delete",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -30,6 +30,7 @@
   "Button_Restart": "Restart",
   "Button_Display_Summary": "Display summary",
   "Remaining_Sips": "sips",
+  "Sip_Modal_Hint": "Tap on a player to give them a sip",
   "Label_Sip": "sip",
   "Label_Sips": "sips",
   "Warning": "Warning",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -20,6 +20,7 @@
   "Button_GoToMenu": "Pause",
   "Button_ResumeGame": "Partie en cours - Reprendre",
   "Button_Cancel": "Annuler",
+  "Button_Confirm": "Confirmer",
   "Dialog_QuitConfirmMessage": "Réinitialiser la partie ? Toutes les données seront perdues.",
   "Button_Create": "Créer",
   "Button_Delete": "Supprimer",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -30,6 +30,7 @@
   "Button_In": "Entre",
   "Button_Out": "Extérieur",
   "Remaining_Sips": "gorgées",
+  "Sip_Modal_Hint": "Tape sur un joueur pour lui donner une gorgée",
   "Label_Sip": "gorgée",
   "Label_Sips": "gorgées",
   "Warning": "Attention",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -222,6 +222,9 @@
       "correct": "Prédiction correcte",
       "incorrect": "Prédiction incorrecte"
     },
+    "phase2": {
+      "drawPile": "Pile de tirage"
+    },
     "progress": {
       "phase1": "Phase 1: Prédictions",
       "phase2": "Phase 2: Distribution",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -29,6 +29,7 @@
   "Button_In": "Binnen",
   "Button_Out": "Buiten",
   "Remaining_Sips": "slokjes",
+  "Sip_Modal_Hint": "Tik op een speler om hem een slokje te geven",
   "Label_Sip": "slok",
   "Label_Sips": "slokken",
   "Warning": "Waarschuwing",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -19,6 +19,7 @@
   "Button_GoToMenu": "Pauze",
   "Button_ResumeGame": "Spel bezig - Hervatten",
   "Button_Cancel": "Annuleren",
+  "Button_Confirm": "Bevestigen",
   "Dialog_QuitConfirmMessage": "Spel resetten? Alle gegevens gaan verloren.",
   "Button_Create": "Maken",
   "Button_Delete": "Verwijderen",


### PR DESCRIPTION
## Summary
- **Split-lane layout** for Phase 2 with drink (left) / give (right) lanes and center draw pile
- **3D card flip animation** on draw with `prefers-reduced-motion` support
- **Glassmorphism give modal** with quick-tap avatar grid for sip distribution
- **Animated sip counters** with bounce/shake on increment, color-coded severity
- **Match highlight** with gold pulse on player cards when drawn card matches
- **Phase 2 sip counters** show only Phase 2 sips (not Phase 1 cumulative)
- **Give modal** uses `sipsGiven`/`getTotalGivenSips` for correct distribution
- **i18n**: added missing `Button_Confirm` translation key (fr/en/de/nl)
- **Code review fixes** (7 patches): reduced-motion for sip-pulse, timer leak fix, reveal guard, stale signal reset, double-tap clamp, phase1Drunk reset, ARIA dialog attributes

## Code Review Summary
Adversarial review performed with 3 parallel layers (Blind Hunter, Edge Case Hunter, Acceptance Auditor).

| Category | Count |
|----------|-------|
| Intent Gap | 2 (spec deviations: split-lane vs pyramid, uniform gold vs red/green highlight) |
| Patch | 7 (all fixed in this PR) |
| Defer | 2 (pre-existing: `getLastCard` return type, Phase 1/2 panel overlap) |
| Rejected | 11 |

## Test plan
- [ ] Start a new game with 3+ players, pass Phase 1
- [ ] Verify Phase 2 split-lane layout with drink/give lanes
- [ ] Draw cards and verify 3D flip animation
- [ ] Trigger a "give" match and verify glassmorphism modal opens
- [ ] Distribute sips in modal, verify "Confirmer" button (was "Button_Confirm")
- [ ] Verify sip counters show Phase 2 only (not Phase 1 cumulative)
- [ ] Test with `prefers-reduced-motion: reduce` enabled
- [ ] Test double-tap on "+all" button in modal (should clamp correctly)
- [ ] Verify no timer accumulation warnings in long games